### PR TITLE
Handle simple object template

### DIFF
--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -117,6 +117,7 @@ class PublicationComponent extends Component
                 },
                 array_reverse($ancestors)
             ),
+            $object['type'] !== 'folders' ? ['object'] : [],
             ['objects']
         );
 


### PR DESCRIPTION
Look for the `object` template for simple (aka non `folders`) objects.