### PR TITLE
Return Query object when loading multiple objects

### DIFF
--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -22,16 +22,12 @@ use Iterator;
  *
  * @property-read \BEdita\Core\Model\Table\ObjectsTable $Objects
  * @property-read \BEdita\Core\Model\Table\ObjectTypesTable $ObjectTypes
- * @property-read \Cake\Controller\Component\PaginatorComponent $Paginator
  */
 class ObjectsComponent extends Component
 {
 
     use I18nTrait;
     use ModelAwareTrait;
-
-    /** {@inheritDoc} */
-    public $components = ['Paginator'];
 
     /**
      * Default configuration.


### PR DESCRIPTION
This PR refactors the method `ObjectsComponent::loadObjects()` so that a Query object is returned in place of a Collection. This ensures loading is even lazier, and it is now possible to furtherly manipulate the Query object by adding conditions or contained associations, selecting fields, sorting or paginating.