### PR TITLE
Introduce object loaders, introduce objects route, refactor components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "cakephp-plugin",
     "license": "MIT",
     "require": {
+        "ext-json": "*",
         "bedita/core": "^4.2.0",
         "cakephp/cakephp": "^3.8",
         "wyrihaximus/twig-view": "^4.3"

--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -35,7 +35,7 @@ class ObjectsComponent extends Component
      *
      * @var \Chialab\FrontendKit\Model\ObjectsLoader
      */
-    protected ObjectsLoader $loader;
+    protected $loader;
 
     /**
      * @inheritdoc

--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -46,7 +46,7 @@ class ObjectsComponent extends Component
 
         $this->loader = new ObjectsLoader(
             $this->getConfig('objectTypesConfig', []),
-            $this->getConfig('autoHydrateAssociations', []),
+            $this->getConfig('autoHydrateAssociations', [])
         );
     }
 

--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -1,21 +1,13 @@
 <?php
 namespace Chialab\FrontendKit\Controller\Component;
 
-use BEdita\Core\Model\Action\GetObjectAction;
-use BEdita\Core\Model\Action\ListObjectsAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Entity\ObjectType;
-use BEdita\I18n\Core\I18nTrait;
-use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Controller\Component;
 use Cake\Datasource\ModelAwareTrait;
-use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Query;
-use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
-use Iterator;
+use Chialab\FrontendKit\Model\ObjectsAwareTrait;
 
 /**
  * Objects component
@@ -25,9 +17,8 @@ use Iterator;
  */
 class ObjectsComponent extends Component
 {
-
-    use I18nTrait;
     use ModelAwareTrait;
+    use ObjectsAwareTrait;
 
     /**
      * Default configuration.
@@ -87,7 +78,7 @@ class ObjectsComponent extends Component
     /**
      * Hydrate an heterogeneous list of objects to their type-specific properties and relations.
      *
-     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
+     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $objects List of objects.
      * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[]
      */
     public function hydrateObjects(array $objects): CollectionInterface
@@ -96,110 +87,19 @@ class ObjectsComponent extends Component
     }
 
     /**
-     * Load a single object knowing its ID and object type.
-     *
-     * @param int $id Object ID.
-     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
-     * @param array|null $options Options.
-     * @param int $depth Depth level.
-     * @return \BEdita\Core\Model\Entity\ObjectEntity
+     * @inheritdoc
      */
-    protected function loadSingle(int $primaryKey, ObjectType $objectType, ?array $options, int $depth = 1): ObjectEntity
+    protected function getOptionsForObjectType(string $objectType): ?array
     {
-        // Fetch default options.
-        if ($options === null) {
-            $options = $this->getDefaultOptions($objectType);
-        }
-
-        $table = TableRegistry::getTableLocator()->get($objectType->alias);
-        $lang = $this->getLang();
-        $contain = static::prepareContains(Hash::get($options, 'include', ''));
-
-        $action = new GetObjectAction(compact('objectType', 'table'));
-        /** @var \BEdita\Core\Model\Entity\ObjectEntity $object */
-        $object = $action(compact('primaryKey', 'lang', 'contain'));
-
-        return $this->autoHydrateAssociations([$object], $depth)->first();
+        return $this->getConfig(sprintf('objectTypesConfig.%s', $objectType));
     }
 
     /**
-     * Load multiple object of a single type applying some filters.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
-     * @param array $filter Filters.
-     * @param array|null $options Options.
-     * @param int $depth Depth level.
-     * @return \Cake\ORM\Query|\BEdita\Core\Model\Entity\ObjectEntity[]
+     * @inheritdoc
      */
-    protected function loadMulti(ObjectType $objectType, array $filter, ?array $options, int $depth = 1): Query
+    protected function getAssociationsToHydrate(int $depth): array
     {
-        // Fetch default options.
-        if ($options === null) {
-            $options = $this->getDefaultOptions($objectType);
-        }
-        $filter += Hash::get($options, 'filter', []);
-
-        $table = TableRegistry::getTableLocator()->get($objectType->alias);
-        $lang = $this->getLang();
-        $contain = static::prepareContains(Hash::get($options, 'include', ''));
-
-        $action = new ListObjectsAction(compact('objectType', 'table'));
-        /** @var \Cake\ORM\Query $query */
-        $query = $action(compact('filter', 'lang', 'contain'));
-
-        return $query->formatResults(function (iterable $results) use ($depth): iterable {
-            return $this->autoHydrateAssociations($results, $depth);
-        });
-    }
-
-    /**
-     * Given a set of objects, re-map them to their concrete type implementation.
-     *
-     * @param iterable|\BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects to re-map to their concrete types.
-     * @param int $depth Depth level.
-     * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[]
-     */
-    protected function toConcreteTypes(iterable $objects, int $depth): CollectionInterface
-    {
-        $objects = new Collection($objects);
-        $sortedIds = $objects->extract('id')->toList();
-
-        return $objects
-            ->combine(
-                'id',
-                function (ObjectEntity $object): ObjectEntity {
-                    return $object;
-                },
-                'type'
-            )
-            ->unfold(function (iterable $items, string $type) use ($depth): Iterator {
-                $objectType = $this->ObjectTypes->get($type);
-                $filter = [
-                    'id' => array_unique((new Collection($items))->extract('id')->toList()),
-                ];
-
-                yield from $this->loadMulti($objectType, $filter, null, $depth);
-            })
-            ->sortBy(function (ObjectEntity $object) use ($sortedIds): int {
-                return array_search($object->id, $sortedIds);
-            }, SORT_ASC)
-            ->compile();
-    }
-
-    /**
-     * Automatically hydrate related objects, up to the configured maximum depth.
-     *
-     * @param iterable|\BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects whose related resources must be hydrated.
-     * @param int $depth Maximum depth.
-     * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[]
-     */
-    protected function autoHydrateAssociations(iterable $objects, int $depth): CollectionInterface
-    {
-        if (!($objects instanceof CollectionInterface)) {
-            $objects = new Collection($objects);
-        }
-
-        $associations = array_keys(
+        return array_keys(
             array_filter(
                 $this->getConfig('autoHydrateAssociations', []),
                 function (int $maxDepth) use ($depth): bool {
@@ -207,86 +107,5 @@ class ObjectsComponent extends Component
                 }
             )
         );
-        if (empty($associations)) {
-            return $objects;
-        }
-
-        return $objects
-            ->each(function (ObjectEntity $object) use ($associations, $depth): void {
-                foreach ($associations as $prop) {
-                    if (!$object->has($prop) || $object->isEmpty($prop)) {
-                        continue;
-                    }
-
-                    $related = $object->get($prop);
-                    if ($related instanceof ObjectEntity) {
-                        $original = $related;
-
-                        $objectType = $this->ObjectTypes->get($related->type);
-                        $related = $this->loadSingle($related->id, $objectType, null, $depth + 1);
-                        if (!$original->isEmpty('_joinData')) {
-                            $related->set('relation', $original->get('_joinData'));
-                            $related->clean();
-                        }
-
-                        $object->set($prop, $related);
-
-                        continue;
-                    }
-
-                    $original = (new Collection($related))->indexBy('id')->toArray();
-
-                    $related = $this->toConcreteTypes($related, $depth + 1)
-                        ->each(function (ObjectEntity $rel) use ($original): void {
-                            $orig = Hash::get($original, $rel->id);
-                            if ($orig === null || $orig->isEmpty('_joinData')) {
-                                return;
-                            }
-
-                            $rel->set('relation', $orig->get('_joinData'));
-                            $rel->clean();
-                        });
-                    $object->set($prop, $related);
-                }
-
-                $object->clean();
-            });
-    }
-
-    /**
-     * Get default options for an object type. If no options are set for the type,
-     * options for the parent types (abstract types) are checked.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
-     * @return array
-     */
-    protected function getDefaultOptions(ObjectType $objectType): array
-    {
-        $options = $this->getConfig(sprintf('objectTypesConfig.%s', $objectType->name));
-        if ($options !== null) {
-            return $options;
-        }
-        if ($objectType->parent_id === null) {
-            return [];
-        }
-
-        $parent = $this->ObjectTypes->get($objectType->parent_id);
-
-        return $this->getDefaultOptions($parent);
-    }
-
-    /**
-     * Parse include comma-delimited string into Cake-compatible contains.
-     *
-     * @param string $include Included associations.
-     * @return string[]
-     */
-    protected static function prepareContains(string $include): array
-    {
-        $contains = explode(',', $include);
-
-        return array_filter(array_map(function (string $assoc): string {
-            return Inflector::camelize(trim($assoc));
-        }, $contains));
     }
 }

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -174,7 +174,7 @@ class PublicationComponent extends Component
      * @param int|null $via If set, restrict paths that include this parent ID.
      * @return array
      */
-    public function getViablePaths(int $id, ?int $via): array
+    public function getViablePaths(int $id, ?int $via = null): array
     {
         return $this->loader->getViablePaths($id, $this->getPublication()->id, $via);
     }

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -42,14 +42,14 @@ class PublicationComponent extends Component
      *
      * @var \Chialab\FrontendKit\Model\TreeLoader
      */
-    protected TreeLoader $loader;
+    protected $loader;
 
     /**
      * Current publication
      *
      * @var \BEdita\Core\Model\Entity\Folder
      */
-    protected Folder $publication;
+    protected $publication;
 
     /**
      * Initialization hook method.

--- a/src/Model/ObjectsAwareTrait.php
+++ b/src/Model/ObjectsAwareTrait.php
@@ -1,0 +1,246 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Model;
+
+use BEdita\Core\Model\Action\GetObjectAction;
+use BEdita\Core\Model\Action\ListObjectsAction;
+use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Model\Entity\ObjectType;
+use BEdita\I18n\Core\I18nTrait;
+use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Query;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+use Iterator;
+
+/**
+ * Trait to help with loading objects.
+ *
+ * @package Chialab\FrontendKit\Model
+ */
+trait ObjectsAwareTrait
+{
+    use I18nTrait;
+    use LocatorAwareTrait;
+
+    /**
+     * Get options to be used when loading an object of the given type.
+     *
+     * @param string $objectType Object type name.
+     * @return array|null Array with options, or `null` to fallback to parent object type.
+     */
+    abstract protected function getOptionsForObjectType(string $objectType): ?array;
+
+    /**
+     * Get names of associations for which related objects need to be hydrated.
+     *
+     * @param int $depth Depth level.
+     * @return string[]
+     */
+    abstract protected function getAssociationsToHydrate(int $depth): array;
+
+    /**
+     * Load a single object knowing its ID and object type.
+     *
+     * @param int $primaryKey Object ID.
+     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
+     * @param array|null $options Options.
+     * @param int $depth Depth level.
+     * @return \BEdita\Core\Model\Entity\ObjectEntity
+     */
+    protected function loadSingle(int $primaryKey, ObjectType $objectType, ?array $options, int $depth = 1): ObjectEntity
+    {
+        // Fetch default options.
+        if ($options === null) {
+            $options = $this->getDefaultOptions($objectType);
+        }
+
+        $table = $this->getTableLocator()->get($objectType->alias);
+        $lang = $this->getLang();
+        $contain = static::prepareContains(Hash::get($options, 'include', ''));
+
+        $action = new GetObjectAction(compact('objectType', 'table'));
+        /** @var \BEdita\Core\Model\Entity\ObjectEntity $object */
+        $object = $action(compact('primaryKey', 'lang', 'contain'));
+
+        return $this->autoHydrateAssociations([$object], $depth)->first();
+    }
+
+    /**
+     * Load multiple object of a single type applying some filters.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
+     * @param array $filter Filters.
+     * @param array|null $options Options.
+     * @param int $depth Depth level.
+     * @return \Cake\ORM\Query|\BEdita\Core\Model\Entity\ObjectEntity[]
+     */
+    protected function loadMulti(ObjectType $objectType, array $filter, ?array $options, int $depth = 1): Query
+    {
+        // Fetch default options.
+        if ($options === null) {
+            $options = $this->getDefaultOptions($objectType);
+        }
+        $filter += Hash::get($options, 'filter', []);
+
+        $table = $this->getTableLocator()->get($objectType->alias);
+        $lang = $this->getLang();
+        $contain = static::prepareContains(Hash::get($options, 'include', ''));
+
+        $action = new ListObjectsAction(compact('objectType', 'table'));
+        /** @var \Cake\ORM\Query $query */
+        $query = $action(compact('filter', 'lang', 'contain'));
+
+        return $query->formatResults(function (iterable $results) use ($depth): iterable {
+            return $this->autoHydrateAssociations($results, $depth);
+        });
+    }
+
+    /**
+     * Given a set of objects, re-map them to their concrete type implementation.
+     *
+     * @param iterable|\BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects to re-map to their concrete types.
+     * @param int $depth Depth level.
+     * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[]
+     */
+    protected function toConcreteTypes(iterable $objects, int $depth): CollectionInterface
+    {
+        $objects = new Collection($objects);
+        $sortedIds = $objects->extract('id')->toList();
+
+        return $objects
+            ->combine(
+                'id',
+                function (ObjectEntity $object): ObjectEntity {
+                    return $object;
+                },
+                'type'
+            )
+            ->unfold(function (iterable $items, string $type) use ($depth): Iterator {
+                $objectType = $this->getObjectType($type);
+                $filter = [
+                    'id' => array_unique((new Collection($items))->extract('id')->toList()),
+                ];
+
+                yield from $this->loadMulti($objectType, $filter, null, $depth);
+            })
+            ->sortBy(function (ObjectEntity $object) use ($sortedIds): int {
+                return array_search($object->id, $sortedIds);
+            }, SORT_ASC)
+            ->compile();
+    }
+
+    /**
+     * Automatically hydrate related objects, up to the configured maximum depth.
+     *
+     * @param iterable|\BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects whose related resources must be hydrated.
+     * @param int $depth Maximum depth.
+     * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[]
+     */
+    protected function autoHydrateAssociations(iterable $objects, int $depth): CollectionInterface
+    {
+        if (!($objects instanceof CollectionInterface)) {
+            $objects = new Collection($objects);
+        }
+
+        $associations = $this->getAssociationsToHydrate($depth);
+        if (empty($associations)) {
+            return $objects;
+        }
+
+        return $objects
+            ->each(function (ObjectEntity $object) use ($associations, $depth): void {
+                foreach ($associations as $prop) {
+                    if (!$object->has($prop) || $object->isEmpty($prop)) {
+                        continue;
+                    }
+
+                    $related = $object->get($prop);
+                    if ($related instanceof ObjectEntity) {
+                        $original = $related;
+
+                        $objectType = $this->getObjectType($related->type);
+                        $related = $this->loadSingle($related->id, $objectType, null, $depth + 1);
+                        if (!$original->isEmpty('_joinData')) {
+                            $related->set('relation', $original->get('_joinData'));
+                            $related->clean();
+                        }
+
+                        $object->set($prop, $related);
+
+                        continue;
+                    }
+
+                    $original = (new Collection($related))->indexBy('id')->toArray();
+
+                    $related = $this->toConcreteTypes($related, $depth + 1)
+                        ->each(function (ObjectEntity $rel) use ($original): void {
+                            $orig = Hash::get($original, $rel->id);
+                            if ($orig === null || $orig->isEmpty('_joinData')) {
+                                return;
+                            }
+
+                            $rel->set('relation', $orig->get('_joinData'));
+                            $rel->clean();
+                        });
+                    $object->set($prop, $related);
+                }
+
+                $object->clean();
+            });
+    }
+
+    /**
+     * Get an object type by its name.
+     *
+     * @param string $name Object type name.
+     * @return \BEdita\Core\Model\Entity\ObjectType
+     */
+    protected function getObjectType(string $name): ObjectType
+    {
+        /** @var \BEdita\Core\Model\Table\ObjectTypesTable $table */
+        $table = $this->getTableLocator()->get('ObjectTypes');
+
+        return $table->get($name);
+    }
+
+    /**
+     * Get default options for an object type. If no options are set for the type,
+     * options for the parent types (abstract types) are checked.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType $objectType Object type.
+     * @return array
+     */
+    protected function getDefaultOptions(ObjectType $objectType): array
+    {
+        $options = $this->getOptionsForObjectType($objectType->name);
+        if ($options !== null) {
+            return $options;
+        }
+        if ($objectType->parent_id === null) {
+            return [];
+        }
+
+        $parent = $this->ObjectTypes->get($objectType->parent_id);
+
+        return $this->getDefaultOptions($parent);
+    }
+
+    /**
+     * Parse include comma-delimited string into Cake-compatible contains.
+     *
+     * @param string $include Included associations.
+     * @return string[]
+     */
+    protected static function prepareContains(string $include): array
+    {
+        $contains = explode(',', $include);
+
+        return array_filter(array_map(function (string $assoc): string {
+            return Inflector::camelize(trim($assoc));
+        }, $contains));
+    }
+}

--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -36,7 +36,7 @@ class ObjectsLoader
      *
      * @var array[]
      */
-    protected array $objectTypesConfig = [];
+    protected $objectTypesConfig = [];
 
     /**
      * Map of associations that need to be hydrated to the actual object types
@@ -44,7 +44,7 @@ class ObjectsLoader
      *
      * @var int[]
      */
-    protected array $autoHydrateAssociations = [];
+    protected $autoHydrateAssociations = [];
 
     /**
      * Objects loader constructor.

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -51,7 +51,7 @@ class TreeLoader
     public function loadObjectPath(string $path, ?int $relativeTo = null): CollectionInterface
     {
         $parts = array_filter(explode('/', $path));
-        $path = implode($parts, '/');
+        $path = implode('/', $parts);
         $leaf = $this->loader->loadObject(array_pop($parts));
 
         $found = $this->getObjectPaths($leaf->id, $relativeTo)

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Model;
+
+use BEdita\Core\Model\Entity\Folder;
+use Cake\Collection\CollectionInterface;
+use Cake\Database\Expression\Comparison;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Datasource\ModelAwareTrait;
+use Cake\ORM\Query;
+
+/**
+ * Class TreeLoader
+ *
+ * @package Chialab\FrontendKit\Model
+ *
+ * @property \BEdita\Core\Model\Table\TreesTable $Trees
+ */
+class TreeLoader
+{
+    use ModelAwareTrait;
+
+    /**
+     * Objects loader instance.
+     *
+     * @var \Chialab\FrontendKit\Model\ObjectsLoader
+     */
+    protected ObjectsLoader $loader;
+
+    /**
+     * Tree loader constructor.
+     *
+     * @param \Chialab\FrontendKit\Model\ObjectsLoader $loader Objects loader instance.
+     */
+    public function __construct(ObjectsLoader $loader)
+    {
+        $this->loader = $loader;
+
+        $this->loadModel('Trees');
+    }
+
+    /**
+     * Load all objects in a path.
+     *
+     * @param string $path Path.
+     * @param int|null $relativeTo ID of parent relative to which compute paths.
+     * @return \Cake\Collection\CollectionInterface|\BEdita\Core\Model\Entity\ObjectEntity[] List of objects, the root element in the path being the first in the list, the leaf being the latter.
+     */
+    public function loadObjectPath(string $path, ?int $relativeTo = null): CollectionInterface
+    {
+        $parts = array_filter(explode('/', $path));
+        $path = implode($parts, '/');
+        $leaf = $this->loader->loadObject(array_pop($parts));
+
+        $found = $this->getObjectPaths($leaf->id, $relativeTo)
+            ->having(compact('path'))
+            ->firstOrFail();
+
+        $ids = explode(',', $found['path_ids']);
+
+        $leaf = $this->loader->loadObject((string)$leaf->id, $leaf->type);
+
+        return $this->loader->loadObjects(['id' => $ids], 'folders')
+            ->sortBy(function (Folder $folder) use ($ids): int {
+                return array_search($folder->id, $ids);
+            }, SORT_ASC)
+            ->append([$leaf]);
+    }
+
+    /**
+     * Get list of viable paths for an object in the current context.
+     *
+     * @param int $id Object ID.
+     * @param int|null $relativeTo ID of parent relative to which compute paths.
+     * @param int|null $via ID of requested parent.
+     * @return array[]
+     */
+    public function getViablePaths(int $id, ?int $relativeTo, ?int $via = null): array
+    {
+        $query = $this->getObjectPaths($id, $relativeTo);
+        if ($via !== null) {
+            $query = $query->having(new FunctionExpression('BIT_OR', [
+                new Comparison($this->Trees->ParentNode->aliasField('object_id'), $via, 'integer', '=')
+            ]));
+        }
+
+        return $query->toList();
+    }
+
+    /**
+     * Prepare query to find all tree paths given an object ID, optionally computing relative paths to another object.
+     *
+     * @param int $id Object ID.
+     * @param int|null $relativeTo Object ID relative to which paths should be computed.
+     * @return \Cake\ORM\Query
+     */
+    protected function getObjectPaths(int $id, ?int $relativeTo = null): Query
+    {
+        $query = $this->Trees->find()
+            ->select([$this->Trees->aliasField('canonical')])
+            ->where([$this->Trees->aliasField('object_id') => $id])
+            ->group([$this->Trees->aliasField('id'), $this->Trees->aliasField('canonical')]);
+
+        // Join with parent nodes, up to the requested node.
+        $exp = $query->newExpr()
+            ->eq(
+                new IdentifierExpression($this->Trees->ParentNode->aliasField('root_id')),
+                new IdentifierExpression($this->Trees->aliasField('root_id'))
+            )
+            ->lte(
+                new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_left')),
+                new IdentifierExpression($this->Trees->aliasField('tree_left'))
+            )
+            ->gte(
+                new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_right')),
+                new IdentifierExpression($this->Trees->aliasField('tree_right'))
+            );
+        if ($relativeTo !== null) {
+            $exp = $exp
+                ->gt(
+                    new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_left')),
+                    $this->Trees->find()
+                        ->select([$this->Trees->aliasField('tree_left')])
+                        ->where([$this->Trees->aliasField('object_id') => $relativeTo])
+                )
+                ->lt(
+                    new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_right')),
+                    $this->Trees->find()
+                        ->select([$this->Trees->aliasField('tree_right')])
+                        ->where([$this->Trees->aliasField('object_id') => $relativeTo])
+                );
+        }
+        $query = $query
+            ->select([
+                // TODO: use QueryExpressions for this:
+                'path_ids' => 'GROUP_CONCAT(ParentNode.object_id ORDER BY ParentNode.tree_left SEPARATOR \',\')',
+            ])
+            ->innerJoin(
+                [$this->Trees->ParentNode->getName() => $this->Trees->ParentNode->getTable()],
+                $exp
+            );
+
+        // Join with objects to get path unames.
+        $query = $query
+            ->select([
+                // TODO: use QueryExpressions for this:
+                'path' => 'GROUP_CONCAT(Objects.uname ORDER BY ParentNode.tree_left SEPARATOR \'/\')',
+            ])
+            ->innerJoin(
+                [$this->Trees->ParentNode->Objects->getName() => $this->Trees->ParentNode->Objects->getTable()],
+                $query->newExpr()
+                    ->eq(
+                        new IdentifierExpression($this->Trees->ParentNode->Objects->aliasField('id')),
+                        new IdentifierExpression($this->Trees->ParentNode->aliasField('object_id'))
+                    )
+            );
+
+        return $query->disableHydration();
+    }
+}

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -27,7 +27,7 @@ class TreeLoader
      *
      * @var \Chialab\FrontendKit\Model\ObjectsLoader
      */
-    protected ObjectsLoader $loader;
+    protected $loader;
 
     /**
      * Tree loader constructor.

--- a/src/Routing/Route/ObjectRoute.php
+++ b/src/Routing/Route/ObjectRoute.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Routing\Route;
+
+use ArrayAccess;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Utility\Hash;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Matches object entities to routes.
+ *
+ * This route will match by entity and map its fields to the URL pattern by
+ * comparing the field names with the template vars. This makes it easy and
+ * convenient to change routes globally.
+ */
+class ObjectRoute extends DashedRoute
+{
+    /**
+     * Match by entity and map its fields to the URL pattern by comparing the
+     * field names with the template vars.
+     *
+     * If a routing key is defined in both `$url` and the entity, the value defined
+     * in `$url` will be preferred.
+     *
+     * @param array $url Array of parameters to convert to a string.
+     * @param array $context An array of the current request context.
+     *   Contains information such as the current host, scheme, port, and base
+     *   directory.
+     * @return bool|string Either false or a string URL.
+     */
+    public function match(array $url, array $context = [])
+    {
+        if (empty($this->_compiledRoute)) {
+            $this->compile();
+        }
+        if (!isset($url['_entity'])) {
+            return parent::match($url, $context);
+        }
+
+        $entity = $url['_entity'];
+        $this->checkEntity($entity);
+        if (!empty($url['_filters']) && $this->checkFilters($entity, $url['_filters']) === false) {
+            return false;
+        }
+
+        foreach ($this->keys as $field) {
+            if (!isset($url[$field]) && isset($entity[$field])) {
+                $url[$field] = $entity[$field];
+            }
+        }
+
+        return parent::match($url, $context);
+    }
+
+    /**
+     * Checks that we really deal with an entity object
+     *
+     * @param \ArrayAccess|array $entity Entity value from the URL options
+     * @return void
+     * @throws \RuntimeException
+     */
+    protected function checkEntity($entity)
+    {
+        if (!$entity instanceof ArrayAccess && !is_array($entity)) {
+            throw new RuntimeException(sprintf(
+                'Route `%s` expects the URL option `_entity` to be an array or object implementing \ArrayAccess, but `%s` passed.',
+                $this->template,
+                getTypeName($entity)
+            ));
+        }
+    }
+
+    /**
+     * Check if Object matches route filters.
+     *
+     * @param \ArrayAccess|array $entity Entity value from the URL options.
+     * @param array $filters Filters from the URL options.
+     * @return bool
+     */
+    protected function checkFilters($entity, $filters = []): bool
+    {
+        foreach ($filters as $filter => $values) {
+            switch ($filter) {
+                case 'type':
+                    if ($values !== '*' && (empty($entity['type']) || !in_array($entity['type'], (array)$values))) {
+                        return false;
+                    }
+                    break;
+
+                case 'parent':
+                    if (empty($entity['parents'])) {
+                        return false;
+                    }
+                    $parents = Hash::extract($entity['parents'], '{*}.uname');
+                    if (count(array_intersect($parents, (array)$values)) === 0) {
+                        return false;
+                    }
+                    break;
+
+                default:
+                    throw new InvalidArgumentException(sprintf(
+                        'Unknown route filter "%s"',
+                        $filter
+                    ));
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/View/Helper/EncoreHelper.php
+++ b/src/View/Helper/EncoreHelper.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Chialab\FrontendKit\View\Helper;
 
 use Cake\Core\Plugin;
@@ -13,12 +15,13 @@ use Cake\View\Helper;
 class EncoreHelper extends Helper
 {
 
+    /**
+     * @inheritdoc
+     */
     public $helpers = ['Html'];
 
     /**
-     * Default configuration.
-     *
-     * @var array
+     * @inheritdoc
      */
     protected $_defaultConfig = [
         'buildPath' => 'webroot' . DS . 'build',
@@ -30,7 +33,7 @@ class EncoreHelper extends Helper
      *
      * @var array
      */
-    protected $cache = [];
+    protected array $cache = [];
 
     /**
      * Load entrypoints for a frontend plugin.
@@ -83,7 +86,7 @@ class EncoreHelper extends Helper
      * Get css assets.
      *
      * @param string $asset The assets name.
-     * @return array A list of css resources.
+     * @return string HTML to load CSS resources.
      */
     public function css(string $asset): string
     {
@@ -99,7 +102,7 @@ class EncoreHelper extends Helper
      * Get js assets.
      *
      * @param string $asset The assets name.
-     * @return array A list of js resources.
+     * @return string HTML to load JS resources.
      */
     public function script(string $asset): string
     {

--- a/src/View/Helper/EncoreHelper.php
+++ b/src/View/Helper/EncoreHelper.php
@@ -33,7 +33,7 @@ class EncoreHelper extends Helper
      *
      * @var array
      */
-    protected array $cache = [];
+    protected $cache = [];
 
     /**
      * Load entrypoints for a frontend plugin.

--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -38,12 +38,16 @@ class PosterHelper extends Helper
     /**
      * Check if a Media's Stream actually exists.
      *
-     * @param \BEdita\Core\Model\Entity\Media $media
+     * @param \BEdita\Core\Model\Entity\ObjectEntity|null $object
      * @return bool
      */
-    protected static function hasValidStream(Media $media): bool
+    protected static function hasValidStream(?ObjectEntity $object): bool
     {
-        $uri = Hash::get($media, 'streams.0.uri');
+        if (!static::isValidImage($object)) {
+            return false;
+        }
+
+        $uri = Hash::get($object, 'streams.0.uri');
         if (empty($uri)) {
             return false;
         }
@@ -71,7 +75,7 @@ class PosterHelper extends Helper
         }
 
         $poster = $posters->first();
-        if ($poster === null || !static::isValidImage($poster)) {
+        if (!static::isValidImage($poster)) {
             return $this->check($object, true);
         }
 
@@ -89,7 +93,7 @@ class PosterHelper extends Helper
     public function getUrl(?ObjectEntity $object, bool $forceSelf = false, int $variant = 0): ?string
     {
         if ($object === null || $forceSelf) {
-            if (static::isValidImage($object) && static::hasValidStream($object)) {
+            if (static::hasValidStream($object)) {
                 return $object->get('mediaUrl');
             }
 
@@ -102,7 +106,7 @@ class PosterHelper extends Helper
         }
 
         $poster = $posters->first();
-        if ($poster === null || !static::isValidImage($poster)) {
+        if (!static::isValidImage($poster)) {
             return $this->getUrl($object, true);
         }
 

--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -1,8 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Chialab\FrontendKit\View\Helper;
 
 use Cake\View\Helper;
-use Cake\View\View;
 use Cake\Collection\Collection;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use BEdita\Core\Model\Entity\Media;
@@ -60,7 +61,7 @@ class PosterHelper extends Helper
      */
     public function check(?ObjectEntity $object, bool $forceSelf = false, int $variant = 0): bool
     {
-        if ($forceSelf) {
+        if ($object === null || $forceSelf) {
             return static::isValidImage($object);
         }
 
@@ -87,7 +88,7 @@ class PosterHelper extends Helper
      */
     public function getUrl(?ObjectEntity $object, bool $forceSelf = false, int $variant = 0): ?string
     {
-        if ($forceSelf) {
+        if ($object === null || $forceSelf) {
             if (static::isValidImage($object) && static::hasValidStream($object)) {
                 return $object->get('mediaUrl');
             }


### PR DESCRIPTION
This is an all-in-one PR for:

- [x] extracting reusable logic from `ObjectsComponent` and `PublicationComponent` to `ObjectsLoader` and `TreeLoader`, respectively
- [x] refactoring `ObjectsComponent` and `PublicationComponent` to use these new loaders
- [x] introduce a new `ObjectsRoute` to match a route based on an object's properties
- [x] introduce some random fixes in random places