### PR TITLE
Canonical path first

### DIFF
--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -106,7 +106,8 @@ class TreeLoader
         $query = $this->Trees->find()
             ->select([$this->Trees->aliasField('canonical')])
             ->where([$this->Trees->aliasField('object_id') => $id])
-            ->group([$this->Trees->aliasField('id'), $this->Trees->aliasField('canonical')]);
+            ->group([$this->Trees->aliasField('id'), $this->Trees->aliasField('canonical')])
+            ->orderDesc($this->Trees->aliasField('canonical'));
 
         // Join with parent nodes, up to the requested node.
         $exp = $query->newExpr()

--- a/src/View/Helper/MediaHelper.php
+++ b/src/View/Helper/MediaHelper.php
@@ -61,6 +61,11 @@ class MediaHelper extends Helper
      */
     public function getStream(Media $media): ?Stream
     {
+        if (empty($media->media_url)) {
+            // Dirty workaround to load streams that are fetched only on media_url property access.
+            return null;
+        }
+
         if (!$media->has('streams') || !is_iterable($media->streams)) {
             return null;
         }


### PR DESCRIPTION
This MR fixes an issue where the first path returned by `TreeLoader::getViablePath()` might not have been the canonical one, which in turn could lead to the non-canonical path being chosen for subsequent operations.