### PR TITLE
Publication loader

### DIFF
--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -66,11 +66,12 @@ class ObjectsComponent extends Component
      * @param string|int $id Object ID or uname.
      * @param string $type Object type name.
      * @param array|null $options Additional options (e.g.: `['include' => 'children']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['children' => 2]`).
      * @return \BEdita\Core\Model\Entity\ObjectEntity
      */
-    public function loadObject(string $id, string $type = 'objects', ?array $options = null): ObjectEntity
+    public function loadObject(string $id, string $type = 'objects', ?array $options = null, ?array $hydrate = null): ObjectEntity
     {
-        return $this->loader->loadObject($id, $type, $options);
+        return $this->loader->loadObject($id, $type, $options, $hydrate);
     }
 
     /**
@@ -78,12 +79,13 @@ class ObjectsComponent extends Component
      *
      * @param array $filter Filters.
      * @param string $type Object type name.
-     * @param array|null $options Additional options (e.g.: `['include' => 'children']`)
+     * @param array|null $options Additional options (e.g.: `['include' => 'children']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['children' => 2]`).
      * @return \Cake\ORM\Query|\BEdita\Core\Model\Entity\ObjectEntity[]
      */
-    public function loadObjects(array $filter, string $type = 'objects', ?array $options = null): Query
+    public function loadObjects(array $filter, string $type = 'objects', ?array $options = null, ?array $hydrate = null): Query
     {
-        return $this->loader->loadObjects($filter, $type, $options);
+        return $this->loader->loadObjects($filter, $type, $options, $hydrate);
     }
 
     /**

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -7,6 +7,7 @@ use BEdita\Core\Model\Entity\Folder;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Collection\CollectionInterface;
 use Cake\Controller\Component;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
@@ -80,10 +81,12 @@ class PublicationComponent extends Component
             );
         }
 
-        $publication = $publicationLoader->loadObject($publicationUname, 'folders');
-        if (empty($publication)) {
-            throw new NotFoundException(__('Root folder does not exist: {0}', $publicationUname));
+        try {
+            $publication = $publicationLoader->loadObject($publicationUname, 'folders');
+        } catch (RecordNotFoundException $e) {
+            throw new NotFoundException(__('Root folder does not exist: {0}', $publicationUname), null, $e);
         }
+
         $this->publication = $publication;
         $this->getController()->set('publication', $this->publication);
 


### PR DESCRIPTION
This PR adds support for an optional configuration to load `publication` folder with different settings than other objects.

This enables optimizing the loading time and memory usage, since usually `publication` won't need as deep auto-hydrate settings as other objects.

--
**Update:** an optional parameter has been added to `loadObject()`/`loadObjects()` to allow overriding auto-hydrate configuration