### PR TITLE
Check if poster property is defined

### DIFF
--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -305,9 +305,11 @@ class PosterHelper extends Helper
             $streams = $object->streams;
         }
 
-        $poster = collection($object->poster)->first();
-        if ($poster !== null) {
-            $streams = $poster->streams;
+        if (isset($object->poster)) {
+            $poster = collection($object->poster)->first();
+            if ($poster !== null) {
+                $streams = $poster->streams;
+            }
         }
 
         if (empty($streams)) {


### PR DESCRIPTION
Add a check for `poster` property in case of `Media` entities.