### PR TITLE
Poster helper position with collections

### DIFF
--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -260,7 +260,11 @@ class PosterHelper extends Helper
             return '';
         }
 
-        if (empty($props) || !isset($props['position_x']) || !isset($props['position_y'])) {
+        if (!empty($props['position'])) {
+            return $props['position'];
+        }
+
+        if (!isset($props['position_x']) || !isset($props['position_y'])) {
             return '';
         }
 

--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -249,8 +249,11 @@ class PosterHelper extends Helper
             $props = $object->custom_props;
         }
 
-        if (isset($object->poster[0])) {
-            $props = $object->poster[0]->custom_props;
+        if (isset($object->poster)) {
+            $poster = collection($object->poster)->first();
+            if ($poster !== null) {
+                $props = $poster->custom_props;
+            }
         }
 
         if (empty($props)) {


### PR DESCRIPTION
This PR fixes an issue in the `PosterHelper::position` method that tries to access the `poster` property as array. Since related objects can be loaded as iterators, we are going to treat it as generic collection.

Plus: handle custom property `position` as well.