### PR TITLE
Refactor fallback action

### DIFF
--- a/src/Controller/Component/CategoriesComponent.php
+++ b/src/Controller/Component/CategoriesComponent.php
@@ -12,7 +12,7 @@ use Cake\Utility\Text;
 use InvalidArgumentException;
 
 /**
- * Objects component
+ * Categories component
  *
  * @property-read \BEdita\Core\Model\Table\CategoriesTable $Categories
  */

--- a/src/Controller/Component/FiltersComponent.php
+++ b/src/Controller/Component/FiltersComponent.php
@@ -2,6 +2,7 @@
 namespace Chialab\FrontendKit\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Utility\Hash;
 
 /**
  * Filters component.
@@ -30,8 +31,11 @@ class FiltersComponent extends Component
         $request = $this->getController()->getRequest();
 
         $params = $this->getConfig('params');
-        if (isset($params['query']) && !empty($request->getQuery($params['query']))) {
-            $filter['query'] = $request->getQuery($params['query']);
+        foreach ($params as $dest => $source) {
+            $value = $request->getQuery($source);
+            if ($value !== null) {
+                $filter = Hash::insert($filter, $dest, $value);
+            }
         }
 
         return $filter;

--- a/src/Controller/Component/FiltersComponent.php
+++ b/src/Controller/Component/FiltersComponent.php
@@ -1,0 +1,39 @@
+<?php
+namespace Chialab\FrontendKit\Controller\Component;
+
+use Cake\Controller\Component;
+
+/**
+ * Filters component.
+ */
+class FiltersComponent extends Component
+{
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'params' => [
+            'query' => 'q',
+        ],
+    ];
+
+    /**
+     * Convert query params to BEdita filter array.
+     *
+     * @return array The filter array.
+     */
+    public function fromQuery(): array
+    {
+        $filter = [];
+        $request = $this->getController()->getRequest();
+
+        $params = $this->getConfig('params');
+        if (isset($params['query']) && !empty($request->getQuery($params['query']))) {
+            $filter['query'] = $request->getQuery($params['query']);
+        }
+
+        return $filter;
+    }
+}

--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -25,10 +25,9 @@ class ObjectsComponent extends Component
     protected $_defaultConfig = [
         'objectTypesConfig' => [
             'objects' => ['include' => 'poster'],
-            'folders' => ['include' => 'children,parents,poster'],
+            'folders' => ['include' => 'children,poster'],
         ],
         'autoHydrateAssociations' => [
-            'parents' => 2,
             'children' => 3,
         ],
         'extraRelations' => ['parents'],

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -140,7 +140,7 @@ class PublicationComponent extends Component
 
         if ($object->type === 'folders') {
             $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $childrenFilters);
-            $children = $this->getController()->paginate($children->order([], true), ['order' => ['Trees.tree_left']]);
+            $children = $this->getController()->paginate($children->order([], true), ['order' => ['Trees.tree_left']])->toList();
             $object['children'] = $children;
 
             $this->getController()->set(compact('children'));

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -134,11 +134,9 @@ class PublicationComponent extends Component
      */
     public function genericTreeAction(string $path = '', array $childrenFilters = []): Response
     {
-        $items = $this->loadObjectPath($path)->toList();
-
-        $object = $this->getLeaf($items);
-        $ancestors = $this->getAncestors($items);
-        $parent = $this->getParent($items);
+        $ancestors = $this->loadObjectPath($path)->toList();
+        $object = array_pop($ancestors);
+        $parent = end($ancestors) ?: null;
 
         if ($object->type === 'folders') {
             $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $childrenFilters);
@@ -174,40 +172,5 @@ class PublicationComponent extends Component
     public function getViablePaths(int $id, ?int $via = null): array
     {
         return $this->loader->getViablePaths($id, $this->getPublication()->id, $via);
-    }
-
-    /**
-     * Extract the leaf object from a list of objects.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
-     * @return \BEdita\Core\Model\Entity\ObjectEntity|null The leaf object.
-     */
-    public function getLeaf(array $items): ?ObjectEntity
-    {
-        return $items[count($items) - 1] ?? null;
-    }
-
-    /**
-     * Extract a list of ancestors for a list og objects.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
-     * @return \BEdita\Core\Model\Entity\Folder[] Ancestor objects.
-     */
-    public function getAncestors(array $items): array
-    {
-        return array_slice($items, 0, -1);
-    }
-
-    /**
-     * Extract the parent object from a list of objects.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
-     * @return \BEdita\Core\Model\Entity\Folder|null The parent object.
-     */
-    public function getParent(array $items): ?Folder
-    {
-        $ancestors = $this->getAncestors($items);
-
-        return $ancestors[count($ancestors) - 1] ?? null;
     }
 }

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -182,7 +182,7 @@ class PublicationComponent extends Component
      * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
      * @return \BEdita\Core\Model\Entity\ObjectEntity|null The leaf object.
      */
-    public function getLeaf(array $items): ObjectEntity|null
+    public function getLeaf(array $items): ?ObjectEntity
     {
         return $items[count($items) - 1] ?? null;
     }
@@ -204,7 +204,7 @@ class PublicationComponent extends Component
      * @param \BEdita\Core\Model\Entity\ObjectEntity[] $items List of objects.
      * @return \BEdita\Core\Model\Entity\Folder|null The parent object.
      */
-    public function getParent(array $items): Folder|null
+    public function getParent(array $items): ?Folder
     {
         $ancestors = $this->getAncestors($items);
 

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -11,9 +11,9 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
-use Cake\View\Exception\MissingTemplateException;
 use Chialab\FrontendKit\Model\ObjectsLoader;
 use Chialab\FrontendKit\Model\TreeLoader;
+use Chialab\FrontendKit\Traits\RenderTrait;
 use InvalidArgumentException;
 
 /**
@@ -25,6 +25,7 @@ use InvalidArgumentException;
 class PublicationComponent extends Component
 {
     use ModelAwareTrait;
+    use RenderTrait;
 
     /**
      * {@inheritDoc}
@@ -105,6 +106,14 @@ class PublicationComponent extends Component
     }
 
     /**
+     * Render a view using the bound controller.
+     */
+    public function render($view = null, $layout = null)
+    {
+        return $this->getController()->render($view, $layout);
+    }
+
+    /**
      * Getter for publication.
      *
      * @return \BEdita\Core\Model\Entity\Folder
@@ -154,52 +163,8 @@ class PublicationComponent extends Component
             $this->getController()->set(compact('children'));
         }
 
+
         return $this->renderFirstTemplate(...$this->getTemplatesToIterate($object, ...array_reverse($ancestors)));
-    }
-
-    /**
-     * Generate a list of templates to try to use for the given object.
-     *
-     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The main object.
-     * @param \BEdita\Core\Model\Entity\Folder $ancestors A list of ancestors.
-     * @return \Generator A generator function.
-     */
-    protected function getTemplatesToIterate(ObjectEntity $object, Folder ...$ancestors): \Generator
-    {
-        yield $object->uname;
-
-        $chain = iterator_to_array($object->object_type->getFullInheritanceChain());
-        foreach ($ancestors as $ancestor) {
-            foreach ($chain as $type) {
-                yield sprintf('%s.%s', $ancestor->uname, $type->name);
-            }
-        }
-
-        $type = array_shift($chain);
-        yield $type->name;
-
-        foreach ($chain as $type) {
-            yield $type->name;
-        }
-    }
-
-    /**
-     * Render first found template.
-     *
-     * @param string ...$templates Templates to search.
-     * @return \Cake\Http\Response
-     */
-    public function renderFirstTemplate(string ...$templates): Response
-    {
-        foreach ($templates as $template) {
-            try {
-                return $this->getController()->render($template);
-            } catch (MissingTemplateException $e) {
-                continue;
-            }
-        }
-
-        throw new MissingTemplateException(__('None of the searched templates was found'));
     }
 
     /**

--- a/src/Controller/Component/TagsComponent.php
+++ b/src/Controller/Component/TagsComponent.php
@@ -12,7 +12,7 @@ use Cake\Utility\Text;
 use InvalidArgumentException;
 
 /**
- * Objects component
+ * Tags component
  *
  * @property-read \BEdita\Core\Model\Table\TagsTable $Tags
  */

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -38,6 +38,15 @@ trait GenericActionsTrait
     abstract public function getRequest();
 
     /**
+     * Handles pagination of records in Table objects.
+     *
+     * @param \Cake\ORM\Table|string|\Cake\ORM\Query|null $object Table to paginate
+     * @param array $settings The settings/configuration used for pagination.
+     * @return \Cake\ORM\ResultSet|\Cake\Datasource\ResultSetInterface Query results
+     */
+    abstract public function paginate($object = null, array $settings = []);
+
+    /**
      * Generic objects route.
      *
      * @param string $id Object id
@@ -110,7 +119,7 @@ trait GenericActionsTrait
 
             if ($object->type === 'folders') {
                 $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $this->Filters->fromQuery());
-                $children = $this->paginate($children->order([], true), ['order' => ['Trees.tree_left']]);
+                $children = $this->paginate($children->order([], true), ['order' => ['Trees.tree_left']])->toList();
                 $object['children'] = $children;
 
                 $this->set(compact('children'));

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -104,11 +104,9 @@ trait GenericActionsTrait
     public function fallback(string $path): Response
     {
         try {
-            $items = $this->Publication->loadObjectPath($path)->toList();
-
-            $object = $this->Publication->getLeaf($items);
-            $ancestors = $this->Publication->getAncestors($items);
-            $parent = $this->Publication->getParent($items);
+            $ancestors = $this->Publication->loadObjectPath($path)->toList();
+            $object = array_pop($ancestors);
+            $parent = end($ancestors) ?: null;
 
             if ($object->type === 'folders') {
                 $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $this->Filters->fromQuery());

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -28,6 +28,8 @@ use Chialab\FrontendKit\Routing\Route\ObjectRoute;
  */
 trait GenericActionsTrait
 {
+    use RenderTrait;
+
     /**
      * Gets the request instance.
      *
@@ -48,7 +50,7 @@ trait GenericActionsTrait
             $object = $this->Objects->loadFullObject((string)$object->id, $object->type);
             $this->set(compact('object'));
 
-            return $this->Publication->renderFirstTemplate($object->uname, $object->type, 'objects');
+            return $this->renderFirstTemplate($object->uname, $object->type, 'objects');
         } catch (RecordNotFoundException $e) {
             throw new NotFoundException(__('Page not found'), null, $e);
         }
@@ -87,7 +89,7 @@ trait GenericActionsTrait
                 ->extract('name')
                 ->toList();
 
-            return $this->Publication->renderFirstTemplate(...$types);
+            return $this->renderFirstTemplate(...$types);
         } catch (RecordNotFoundException $e) {
             throw new NotFoundException(__('Page not found'), null, $e);
         }

--- a/src/Traits/RenderTrait.php
+++ b/src/Traits/RenderTrait.php
@@ -31,7 +31,7 @@ trait RenderTrait
      * @param string|null $layout Layout to use
      * @return \Cake\Http\Response A response object containing the rendered view.
      */
-    public abstract function render($view = null, $layout = null);
+    abstract public function render($view = null, $layout = null);
 
     /**
      * Generate a list of templates to try to use for the given object.

--- a/src/Traits/RenderTrait.php
+++ b/src/Traits/RenderTrait.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace Chialab\FrontendKit\Traits;
+
+use BEdita\Core\Model\Entity\Folder;
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Http\Response;
+use Cake\View\Exception\MissingTemplateException;
+
+/**
+ * Render for BEdita frontends.
+ */
+trait RenderTrait
+{
+    /**
+     * The render method of the controller.
+     *
+     * @param string|null $view View to use for rendering
+     * @param string|null $layout Layout to use
+     * @return \Cake\Http\Response A response object containing the rendered view.
+     */
+    public abstract function render($view = null, $layout = null);
+
+    /**
+     * Generate a list of templates to try to use for the given object.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The main object.
+     * @param \BEdita\Core\Model\Entity\Folder $ancestors A list of ancestors.
+     * @return \Generator A generator function.
+     */
+    public function getTemplatesToIterate(ObjectEntity $object, Folder ...$ancestors): \Generator
+    {
+        yield $object->uname;
+
+        $chain = iterator_to_array($object->object_type->getFullInheritanceChain());
+        foreach ($ancestors as $ancestor) {
+            foreach ($chain as $type) {
+                yield sprintf('%s.%s', $ancestor->uname, $type->name);
+            }
+        }
+
+        $type = array_shift($chain);
+        yield $type->name;
+
+        foreach ($chain as $type) {
+            yield $type->name;
+        }
+    }
+
+    /**
+     * Render first found template.
+     *
+     * @param string ...$templates Templates to search.
+     * @return \Cake\Http\Response
+     */
+    public function renderFirstTemplate(string ...$templates): Response
+    {
+        foreach ($templates as $template) {
+            try {
+                return $this->render($template);
+            } catch (MissingTemplateException $e) {
+                continue;
+            }
+        }
+
+        throw new MissingTemplateException(__('None of the searched templates was found'));
+    }
+}

--- a/tests/TestCase/Controller/Component/PublicationComponentTest.php
+++ b/tests/TestCase/Controller/Component/PublicationComponentTest.php
@@ -218,7 +218,6 @@ class PublicationComponentTest extends TestCase
      * Test {@see PublicationComponent::genericTreeAction()}.
      *
      * @covers ::genericTreeAction()
-     * @covers ::loadChildren()
      */
     public function testFilteredChildren()
     {
@@ -238,7 +237,6 @@ class PublicationComponentTest extends TestCase
      * Test {@see PublicationComponent::genericTreeAction()}.
      *
      * @covers ::genericTreeAction()
-     * @covers ::loadChildren()
      */
     public function testSortedChildren()
     {
@@ -261,7 +259,6 @@ class PublicationComponentTest extends TestCase
      * Test {@see PublicationComponent::genericTreeAction()}.
      *
      * @covers ::genericTreeAction()
-     * @covers ::loadChildren()
      */
     public function testChildrenParams()
     {

--- a/tests/TestCase/Controller/Component/PublicationComponentTest.php
+++ b/tests/TestCase/Controller/Component/PublicationComponentTest.php
@@ -222,13 +222,13 @@ class PublicationComponentTest extends TestCase
     public function testFilteredChildren()
     {
         $this->Publication->genericTreeAction('parent-1/child-1');
-        $children = $this->controller->viewVars['children']->toList();
+        $children = $this->controller->viewVars['children'];
         static::assertSame(2, count($children));
         static::assertSame('Document 1', $children[0]->title);
         static::assertSame('Profile 1', $children[1]->title);
 
         $this->Publication->genericTreeAction('parent-1/child-1', ['query' => 'Document']);
-        $children = $this->controller->viewVars['children']->toList();
+        $children = $this->controller->viewVars['children'];
         static::assertSame(1, count($children));
         static::assertSame('Document 1', $children[0]->title);
     }
@@ -241,7 +241,7 @@ class PublicationComponentTest extends TestCase
     public function testSortedChildren()
     {
         $this->Publication->genericTreeAction('parent-1/child-1');
-        $children = $this->controller->viewVars['children']->toList();
+        $children = $this->controller->viewVars['children'];
         static::assertSame('Document 1', $children[0]->title);
         static::assertSame('Profile 1', $children[1]->title);
 
@@ -250,7 +250,7 @@ class PublicationComponentTest extends TestCase
             'direction' => 'desc',
         ]);
         $this->Publication->genericTreeAction('parent-1/child-1');
-        $children = $this->controller->viewVars['children']->toList();
+        $children = $this->controller->viewVars['children'];
         static::assertSame('Profile 1', $children[0]->title);
         static::assertSame('Document 1', $children[1]->title);
     }
@@ -263,7 +263,7 @@ class PublicationComponentTest extends TestCase
     public function testChildrenParams()
     {
         $this->Publication->genericTreeAction('parent-1/child-1');
-        $children = $this->controller->viewVars['children']->toList();
+        $children = $this->controller->viewVars['children'];
 
         static::assertSame(true, $children[0]->relation['menu']);
         static::assertSame(false, $children[0]->relation['canonical']);


### PR DESCRIPTION
This PR introduces some changes in order to provide a better way to handle "fallback" action. The fallback action tries to load page contents using a tree path. Previously, this logic was added to the `PublicationComponent`, as well as rendering methods. This PR proposes the following refactors:

* Move `renderFirstTemplate` and `getTemplatesToIterate` methods to a specific `RewnderTrait` that can be used in controllers
* Deprecate the `PublicationComponent::genericTreeAction` in favour of the `GenericActionsTrait::fallback`

---

⚠️ **Opinions section** ⚠️
The following changes are added in order to improve the ergonomics of controllers when we need to define a new action that "works like the fallback but with this little change". Since we encourage to rewrite the full action instead of intercept and modify queries, those methods may help to write a more readable and reusable code.

* Introduce a base `FiltersComponent` that convert query strings to BEdita filter
* Add some helper methods in `PublicationComponent`