### PR TITLE
Draft: Menu component

### DIFF
--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -2,7 +2,6 @@
 namespace Chialab\FrontendKit\Controller\Component;
 
 use BEdita\Core\Model\Entity\Folder;
-use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Controller\Component;
 use Cake\Datasource\ModelAwareTrait;
 use Chialab\FrontendKit\Model\ObjectsLoader;
@@ -18,11 +17,6 @@ class MenuComponent extends Component
     use ModelAwareTrait;
 
     /**
-     * {@inheritDoc}
-     */
-    public $components = ['Chialab/FrontendKit.Objects'];
-
-    /**
      * Objects loader instance.
      *
      * @var \Chialab\FrontendKit\Model\TreeLoader
@@ -35,7 +29,12 @@ class MenuComponent extends Component
      * @var array
      */
     protected $_defaultConfig = [
-        'menuLoader' => null,
+        'menuLoader' => [
+            'objectTypesConfig' => [],
+            'autoHydrateAssociations' => [
+                'children' => 2,
+            ],
+        ],
     ];
 
     /** {@inheritDoc} */
@@ -45,13 +44,10 @@ class MenuComponent extends Component
 
         $this->loadModel('Trees');
 
-        $menuLoader = $this->Objects->getLoader();
-        if ($this->getConfig('menuLoader') !== null) {
-            $menuLoader = new ObjectsLoader(
-                $this->getConfig('menuLoader.objectTypesConfig', []),
-                $this->getConfig('menuLoader.autoHydrateAssociations', [])
-            );
-        }
+        $menuLoader = new ObjectsLoader(
+            $this->getConfig('menuLoader.objectTypesConfig', []),
+            $this->getConfig('menuLoader.autoHydrateAssociations', [])
+        );
 
         $this->loader = new TreeLoader($menuLoader);
     }

--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -1,0 +1,72 @@
+<?php
+namespace Chialab\FrontendKit\Controller\Component;
+
+use BEdita\Core\Model\Entity\Folder;
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Controller\Component;
+use Cake\Datasource\ModelAwareTrait;
+use Chialab\FrontendKit\Model\ObjectsLoader;
+use Chialab\FrontendKit\Model\TreeLoader;
+
+/**
+ * Menu component
+ *
+ * @property-read \BEdita\Core\Model\Table\Trees $Trees
+ */
+class MenuComponent extends Component
+{
+    use ModelAwareTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public $components = ['Chialab/FrontendKit.Objects'];
+
+    /**
+     * Objects loader instance.
+     *
+     * @var \Chialab\FrontendKit\Model\TreeLoader
+     */
+    protected $loader;
+
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'menuLoader' => null,
+    ];
+
+    /** {@inheritDoc} */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->loadModel('Trees');
+
+        $menuLoader = $this->Objects->getLoader();
+        if ($this->getConfig('menuLoader') !== null) {
+            $menuLoader = new ObjectsLoader(
+                $this->getConfig('menuLoader.objectTypesConfig', []),
+                $this->getConfig('menuLoader.autoHydrateAssociations', [])
+            );
+        }
+
+        $this->loader = new TreeLoader($menuLoader);
+    }
+
+    /**
+     * Load a menu graph of folders with param `menu = true`.
+     *
+     * @param string $id The id or uname of the parent folder.
+     * @param array|null $options Additional options (e.g.: `['include' => 'poster']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['poster' => 2]`).
+     * @param int $depth The depth of the menu for recursive loading.
+     * @return \BEdita\Core\Model\Entity\Folder The root menu folder.
+     */
+    public function load(string $id, ?array $options = null, ?array $hydrate = null, ?int $depth = 3): Folder
+    {
+        return $this->loader->loadMenu($id, $options, $hydrate, $depth);
+    }
+}

--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -30,7 +30,6 @@ class ObjectsComponent extends Component
         'autoHydrateAssociations' => [
             'children' => 3,
         ],
-        'extraRelations' => ['parents'],
     ];
 
     /**
@@ -49,8 +48,7 @@ class ObjectsComponent extends Component
 
         $this->loader = new ObjectsLoader(
             $this->getConfig('objectTypesConfig', []),
-            $this->getConfig('autoHydrateAssociations', []),
-            $this->getConfig('extraRelations', [])
+            $this->getConfig('autoHydrateAssociations', [])
         );
     }
 

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Chialab\FrontendKit\Controller\Component;
 
 use BEdita\Core\Model\Entity\Folder;
-use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Collection\CollectionInterface;
 use Cake\Controller\Component;
 use Cake\Datasource\Exception\RecordNotFoundException;

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -78,8 +78,7 @@ class PublicationComponent extends Component
         if ($this->getConfig('publicationLoader') !== null) {
             $publicationLoader = new ObjectsLoader(
                 $this->getConfig('publicationLoader.objectTypesConfig', []),
-                $this->getConfig('publicationLoader.autoHydrateAssociations', []),
-                $this->getConfig('publicationLoader.extraRelations', [])
+                $this->getConfig('publicationLoader.autoHydrateAssociations', [])
             );
         }
         $this->loader = new TreeLoader($publicationLoader);

--- a/src/Controller/Component/PublicationComponent.php
+++ b/src/Controller/Component/PublicationComponent.php
@@ -27,11 +27,6 @@ class PublicationComponent extends Component
     use RenderTrait;
 
     /**
-     * {@inheritDoc}
-     */
-    public $components = ['Chialab/FrontendKit.Objects'];
-
-    /**
      * Default configuration.
      *
      * @var array
@@ -39,7 +34,14 @@ class PublicationComponent extends Component
     protected $_defaultConfig = [
         'menuFolders' => [],
         'publication' => null,
-        'publicationLoader' => null,
+        'publicationLoader' => [
+            'objectTypesConfig' => [
+                'objects' => ['include' => 'poster'],
+            ],
+            'autoHydrateAssociations' => [
+                'children' => 2,
+            ],
+        ],
     ];
 
     /**
@@ -73,13 +75,10 @@ class PublicationComponent extends Component
             throw new InvalidArgumentException('Missing configuration for root folder');
         }
 
-        $publicationLoader = $this->Objects->getLoader();
-        if ($this->getConfig('publicationLoader') !== null) {
-            $publicationLoader = new ObjectsLoader(
-                $this->getConfig('publicationLoader.objectTypesConfig', []),
-                $this->getConfig('publicationLoader.autoHydrateAssociations', [])
-            );
-        }
+        $publicationLoader = new ObjectsLoader(
+            $this->getConfig('publicationLoader.objectTypesConfig', []),
+            $this->getConfig('publicationLoader.autoHydrateAssociations', [])
+        );
         $this->loader = new TreeLoader($publicationLoader);
 
         try {
@@ -137,7 +136,7 @@ class PublicationComponent extends Component
         $parent = end($ancestors) ?: null;
 
         if ($object->type === 'folders') {
-            $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $childrenFilters);
+            $children = $this->getController()->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $childrenFilters);
             $children = $this->getController()->paginate($children->order([], true), ['order' => ['Trees.tree_left']])->toList();
             $object['children'] = $children;
 

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -220,9 +220,9 @@ class TreeLoader
                     return $obj;
                 }
 
-                $folder['children'] = $this->loadChildrenRecursively($obj, $depth - 1, $options, $hydrate);
+                $obj['children'] = $this->loadChildrenRecursively($obj, $depth - 1, $options, $hydrate);
 
-                return $folder;
+                return $obj;
             })->toList();
     }
 }

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -61,7 +61,7 @@ class TreeLoader
         $ids = explode(',', $found['path_ids']);
         array_pop($ids);
 
-        $leaf = $this->loader->loadFullObject((string)$leaf->id, $leaf->type, ['children' => false]);
+        $leaf = $this->loader->loadFullObject((string)$leaf->id, $leaf->type);
 
         if (empty($ids)) {
             return collection([$leaf]);

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Chialab\FrontendKit\Model;
 
 use BEdita\Core\Model\Entity\Folder;
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\FunctionExpression;
@@ -164,5 +165,64 @@ class TreeLoader
             );
 
         return $query->disableHydration();
+    }
+
+    /**
+     * Load menu children.
+     *
+     * @param int|string $id The id or uname of the parent folder.
+     * @param array|null $options Additional options (e.g.: `['include' => 'poster']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['poster' => 2]`).
+     * @return \Cake\ORM\Query
+     */
+    public function loadMenuChildren(string $id, ?array $options = null, ?array $hydrate = null): Query
+    {
+        return $this->loader->loadRelatedObjects($id, 'folders', 'children', [], $options, $hydrate)
+            ->where([$this->Trees->aliasField('menu') => true])
+            ->order([$this->Trees->aliasField('tree_left') => 'ASC'], true);
+    }
+
+    /**
+     * Load a menu graph of folders with param `menu = true`.
+     *
+     * @param string $id The id or uname of the parent folder.
+     * @param array|null $options Additional options (e.g.: `['include' => 'poster']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['poster' => 2]`).
+     * @param int $depth The depth of the menu for recursive loading.
+     * @return \BEdita\Core\Model\Entity\Folder The root menu folder.
+     */
+    public function loadMenu(string $id, ?array $options = null, ?array $hydrate = null, ?int $depth = 3): Folder
+    {
+        $folder = $this->loader->loadObject($id, 'folders', $options, $hydrate);
+        $folder['children'] = $this->loadChildrenRecursively($folder, $depth, $options, $hydrate);
+
+        return $folder;
+    }
+
+    /**
+     * Load menu children of a folder.
+     *
+     * @param \BEdita\Core\Model\Entity\Folder $folder The folder entity.
+     * @param int $depth The depth of the menu for recursive loading.
+     * @param array|null $options Additional options (e.g.: `['include' => 'poster']`).
+     * @param array|null $hydrate Override auto-hydrate options (e.g.: `['poster' => 2]`).
+     * @return \BEdita\Core\Model\Entity\ObjectEntity[] A list of children entities.
+     */
+    protected function loadChildrenRecursively(Folder $folder, int $depth, ?array $options = null, ?array $hydrate = null): array
+    {
+        if ($depth === 0) {
+            return null;
+        }
+
+        return collection($this->loadMenuChildren($folder->uname, $options, $hydrate))
+            ->map(function (ObjectEntity $obj) use ($depth, $options, $hydrate) {
+                if ($obj->type !== 'folders') {
+                    return $obj;
+                }
+
+                $folder['children'] = $this->loadChildrenRecursively($obj, $depth - 1, $options, $hydrate);
+
+                return $folder;
+            })->toList();
     }
 }


### PR DESCRIPTION
Introducing a `MenuComponent` that loads only `menu = true` branches in the tree with a custom `ObjectsLoader` configuration.

It will replace the `PublicationComponent` menu folders loading

## Changes
* `PublicationComponent` no longer loads publication's children. If children were used for main menu generation, you can now use the `MenuComponent`
* Changed the default configuration of the `PublicationComponent`. It is not going to inherit configuration from the default `ObjectsLoader` anymore and it uses a lighter default.