### PR TITLE
Sort by closest range helper method

### DIFF
--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -132,9 +132,7 @@ class DateRangesHelper extends Helper
      */
     public function sortByClosestRange(iterable $objects): array
     {
-        $it = collection($objects)->toArray();
-        usort($it, fn ($a, $b): int => $this->getClosestRange($a->date_ranges ?? [])->start_date->getTimestamp() - $this->getClosestRange($b->date_ranges ?? [])->start_date->getTimestamp());
-
-        return $it;
+        return collection($objects)
+            ->sortBy(fn (ObjectEntity $obj): int => $this->getClosestRange($a->date_ranges ?? [])->start_date->getTimestamp());
     }
 }

--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -123,4 +123,18 @@ class DateRangesHelper extends Helper
 
         return $sorted->last(); // Get closest event in the past, relative to `$now`.
     }
+
+    /**
+     * Sort a list of objects by their closest date.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects to sort.
+     * @return \BEdita\Core\Model\Entity\ObjectEntity[] Sorted objects.
+     */
+    public function sortByClosestRange(iterable $objects): array
+    {
+        $it = collection($objects)->toArray();
+        usort($it, fn ($a, $b): int => $this->getClosestRange($a->date_ranges ?? [])->start_date->getTimestamp() - $this->getClosestRange($b->date_ranges ?? [])->start_date->getTimestamp());
+
+        return $it;
+    }
 }

--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -2,6 +2,7 @@
 namespace Chialab\FrontendKit\View\Helper;
 
 use BEdita\Core\Model\Entity\DateRange;
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\I18n\FrozenTime;
 use Cake\Log\Log;
 use Cake\View\Helper;
@@ -128,11 +129,22 @@ class DateRangesHelper extends Helper
      * Sort a list of objects by their closest date.
      *
      * @param \BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects to sort.
-     * @return \BEdita\Core\Model\Entity\ObjectEntity[] Sorted objects.
+     * @return \Cake\Collection\Collection Sorted objects.
      */
-    public function sortByClosestRange(iterable $objects): array
+    public function sortByClosestRange(iterable $objects): iterable
     {
         return collection($objects)
-            ->sortBy(fn (ObjectEntity $obj): int => $this->getClosestRange($a->date_ranges ?? [])->start_date->getTimestamp());
+            ->sortBy(function (ObjectEntity $obj): int {
+                if (empty($obj->date_ranges)) {
+                    return -INF;
+                }
+
+                $range = $this->getClosestRange($obj->date_ranges);
+                if ($range === null) {
+                    return -INF;
+                }
+
+                return $range->start_date->getTimestamp();
+            });
     }
 }

--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -129,22 +129,19 @@ class DateRangesHelper extends Helper
      * Sort a list of objects by their closest date.
      *
      * @param \BEdita\Core\Model\Entity\ObjectEntity[] $objects Objects to sort.
+     * @param int $dir either SORT_DESC or SORT_ASC.
      * @return \Cake\Collection\Collection Sorted objects.
      */
-    public function sortByClosestRange(iterable $objects): iterable
+    public function sortByClosestRange(iterable $objects, $dir = \SORT_ASC): iterable
     {
         return collection($objects)
-            ->sortBy(function (ObjectEntity $obj): int {
-                if (empty($obj->date_ranges)) {
-                    return -INF;
-                }
-
-                $range = $this->getClosestRange($obj->date_ranges);
+            ->sortBy(function (ObjectEntity $obj): ?int {
+                $range = $this->getClosestRange($obj->date_ranges ?? []);
                 if ($range === null) {
-                    return -INF;
+                    return PHP_INT_MIN;
                 }
 
                 return $range->start_date->getTimestamp();
-            });
+            }, $dir);
     }
 }

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -39,7 +39,7 @@ class DateRangesHelperTest extends TestCase
     protected DateRangesHelper $DateRanges;
 
     /** @inheritDoc */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -49,7 +49,7 @@ class DateRangesHelperTest extends TestCase
     }
 
     /** @inheritDoc */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->DateRanges);
         FrozenTime::setTestNow(null);

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -196,4 +196,40 @@ class DateRangesHelperTest extends TestCase
             static::assertEquals($end, $actual->end_date);
         }
     }
+
+    /**
+     * Test {@see DateRangesHelper::sortByClosestRange()} method.
+     *
+     * @return void
+     *
+     * @covers ::sortByClosestRange()
+     */
+    public function testSortByClosestRange(): void
+    {
+        $items = array_map(function (array $range) {
+            [$id, $start, $end] = $range;
+
+            return (object)[
+                'id' => $id,
+                'date_ranges' => [
+                    new DateRange([
+                        'start_date' => $start,
+                        'end_date' => $end,
+                    ]),
+                ],
+            ];
+        }, [
+            [1, new FrozenTime('1992-08-01T00:00:00'), new FrozenTime('1992-08-31T23:59:59')],
+            [2, new FrozenTime('2023-09-01T00:00:00'), new FrozenTime('2023-09-30T23:59:59')],
+            [3, new FrozenTime('2001-08-01T00:00:00'), new FrozenTime('2001-08-31T23:59:59')],
+            [4, new FrozenTime('2022-09-01T00:00:00'), new FrozenTime('2022-09-30T23:59:59')],
+        ]);
+
+        $sorted = $this->DateRanges->sortByClosestRange($items);
+
+        $expected = [1, 3, 4, 2];
+        $actual = array_map(fn ($item) => $item->id, $sorted);
+
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -1,0 +1,199 @@
+<?php
+namespace Chialab\FrontendKit\Test\TestCase\View\Helper;
+
+use BEdita\Core\Model\Entity\DateRange;
+use Cake\I18n\FrozenTime;
+use Cake\I18n\I18n;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Chialab\FrontendKit\View\Helper\DateRangesHelper;
+
+/**
+ * {@see \Chialab\FrontendKit\View\Helper\DateRangesHelper} Test Case
+ *
+ * @coversDefaultClass \Chialab\FrontendKit\View\Helper\DateRangesHelper
+ */
+class DateRangesHelperTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \Chialab\FrontendKit\View\Helper\DateRangesHelper
+     */
+    protected DateRangesHelper $DateRanges;
+
+    /** @inheritDoc */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->DateRanges = new DateRangesHelper(new View());
+        FrozenTime::setTestNow(new FrozenTime('2020-01-01 00:00:00'));
+        I18n::setLocale('it');
+    }
+
+    /** @inheritDoc */
+    public function tearDown()
+    {
+        unset($this->DateRanges);
+        FrozenTime::setTestNow(null);
+        I18n::setLocale(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for {@see DateRangesHelperTest::testFormatRange()} test case.
+     *
+     * @return array[]
+     */
+    public function formatRangeProvider(): array
+    {
+        return [
+            'single' => [
+                '9 settembre 2021, 11:41',
+                new FrozenTime('2021-09-09T11:41:10'),
+                null,
+            ],
+            'whole day' => [
+                '9 settembre 2021',
+                 new FrozenTime('2021-09-09T00:00:00'),
+                 new FrozenTime('2021-09-09T23:59:59'),
+            ],
+            'time range within same day' => [
+                '9 settembre 2021, dalle 18:15 alle 19:00',
+                new FrozenTime('2021-09-09T18:15:00'),
+                new FrozenTime('2021-09-09T19:00:00'),
+            ],
+            'same month' => [
+                'dal 22 al 25 settembre 2021',
+                new FrozenTime('2021-09-22T18:15:00'),
+                new FrozenTime('2021-09-25T19:00:00'),
+            ],
+            'same year' => [
+                'dal 1 gen al 17 ago 2021',
+                new FrozenTime('2021-01-01T18:15:00'),
+                new FrozenTime('2021-08-17T19:00:00'),
+            ],
+
+            'different year' => [
+                'dal 1 ott 2019 al 16 ott 2020', // musixmatch
+                new FrozenTime('2019-10-01T18:15:00'),
+                new FrozenTime('2020-10-16T19:00:00'),
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see DateRangesHelper::formatRange()} method.
+     *
+     * @param string $expected Expected result.
+     * @param \DateTimeInterface $start Start of range.
+     * @param \DateTimeInterface|null $end End of range.
+     * @return void
+     *
+     * @dataProvider formatRangeProvider()
+     * @covers ::formatRange()
+     */
+    public function testFormatRange(string $expected, \DateTimeInterface $start, ?\DateTimeInterface $end): void
+    {
+        $range = new DateRange([
+            'start_date' => $start,
+            'end_date' => $end,
+        ]);
+        $actual = $this->DateRanges->formatRange($range);
+
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test {@see DateRangesHelper::formatRange()} method when arguments are swapped.
+     *
+     * @return void
+     *
+     * @covers ::formatRange()
+     */
+    public function testFormatRangeSwapped(): void
+    {
+        $range = new DateRange([
+            'start_date' => new FrozenTime('2021-09-09T13:26:31'),
+            'end_date' => new FrozenTime('1992-08-17T05:00:00'),
+        ]);
+        $actual = $this->DateRanges->formatRange($range);
+
+        static::assertSame('dal 17 ago 1992 al 9 set 2021', $actual);
+    }
+
+    /**
+     * Data provider for {@see DateRangesHelperTest::testGetClosestRange()} test case.
+     *
+     * @return array[]
+     */
+    public function getClosestRangeProvider(): array
+    {
+        return [
+            'overlapping' => [
+                [new FrozenTime('2021-09-01T00:00:00'), new FrozenTime('2021-09-30T23:59:59')],
+                [
+                    [new FrozenTime('1992-08-01T00:00:00'), new FrozenTime('1992-08-31T23:59:59')],
+                    [new FrozenTime('2021-09-01T00:00:00'), new FrozenTime('2021-09-30T23:59:59')],
+                    [new FrozenTime('2022-08-01T00:00:00'), new FrozenTime('2022-08-31T23:59:59')],
+                ],
+            ],
+            'all past' => [
+                [new FrozenTime('2001-08-01T00:00:00'), new FrozenTime('2001-08-31T23:59:59')],
+                [
+                    [new FrozenTime('1992-08-01T00:00:00'), new FrozenTime('1992-08-31T23:59:59')],
+                    [new FrozenTime('1999-09-01T00:00:00'), new FrozenTime('1999-09-30T23:59:59')],
+                    [new FrozenTime('2001-08-01T00:00:00'), new FrozenTime('2001-08-31T23:59:59')],
+                ],
+            ],
+            'interlaced' => [
+                [new FrozenTime('2022-09-01T00:00:00'), new FrozenTime('2022-09-30T23:59:59')],
+                [
+                    [new FrozenTime('1992-08-01T00:00:00'), new FrozenTime('1992-08-31T23:59:59')],
+                    [new FrozenTime('2023-09-01T00:00:00'), new FrozenTime('2023-09-30T23:59:59')],
+                    [new FrozenTime('2001-08-01T00:00:00'), new FrozenTime('2001-08-31T23:59:59')],
+                    [new FrozenTime('2022-09-01T00:00:00'), new FrozenTime('2022-09-30T23:59:59')],
+                ],
+            ],
+            'empty' => [
+                null,
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see DateRangesHelper::getClosestRange()} method.
+     *
+     * @param \DateTimeInterface[]|null $expected Expected result.
+     * @param \DateTimeInterface[][] $ranges Ranges.
+     * @return void
+     *
+     * @dataProvider getClosestRangeProvider()
+     * @covers ::getClosestRange()
+     */
+    public function testGetClosestRange(?array $expected, array $ranges): void
+    {
+        $actual = $this->DateRanges->getClosestRange(array_map(
+            function (array $range): DateRange {
+                [$start, $end] = $range;
+
+                return new DateRange([
+                    'start_date' => $start,
+                    'end_date' => $end,
+                ]);
+            },
+            $ranges
+        ));
+
+        if ($expected === null) {
+            static::assertNull($actual);
+        } else {
+            [$start, $end] = $expected;
+            static::assertEquals($start, $actual->start_date);
+            static::assertEquals($end, $actual->end_date);
+        }
+    }
+}


### PR DESCRIPTION
Introduce the `sortByClosestRange` method in `DateRangesHelper`. It can be used to sort in view a list of objects by their closest date range.

Extra: adding tests for `DateRangesHelper`