### PR TITLE
Remove try catch from generic actions

### DIFF
--- a/src/Middleware/ExceptionWrapperMiddleware.php
+++ b/src/Middleware/ExceptionWrapperMiddleware.php
@@ -29,7 +29,7 @@ class ExceptionWrapperMiddleware
      */
     public function __construct()
     {
-        $this->$exceptionMap = [
+        $this->exceptionMap = [
             RecordNotFoundException::class => fn (RecordNotFoundException $e): NotFoundException => new NotFoundException(__('Page not found'), null, $e),
         ];
     }

--- a/src/Middleware/ExceptionWrapperMiddleware.php
+++ b/src/Middleware/ExceptionWrapperMiddleware.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Middleware;
+
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Http\Exception\NotFoundException;
+use Migrations\Migrations;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Exception wrapper middleware.
+ * 
+ * Catch and rethrow mapped exceptions.
+ */
+class ExceptionWrapperMiddleware
+{
+    /**
+     * Exceptions map.
+     *
+     * @var array<class-string, callable>
+     */
+    protected array $exceptionMap = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct()
+    {
+        $this->$exceptionMap = [
+            RecordNotFoundException::class => fn (RecordNotFoundException $e): NotFoundException => new NotFoundException(__('Page not found'), null, $e),
+        ];
+    }
+
+    /**
+     * Invoke method.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next Callback to invoke the next middleware.
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
+    {
+        try {
+            return $next($request, $response);
+        } catch (Throwable $e) {
+            $ctr = get_class($e);
+            if (!isset($this->exceptionMap[$ctr])) {
+                throw $e;
+            }
+
+            $cb = $this->exceptionMap[$ctr];
+
+            throw $cb($e);
+        }
+    }
+}

--- a/src/Middleware/ExceptionWrapperMiddleware.php
+++ b/src/Middleware/ExceptionWrapperMiddleware.php
@@ -12,7 +12,7 @@ use Throwable;
 
 /**
  * Exception wrapper middleware.
- * 
+ *
  * Catch and rethrow mapped exceptions.
  */
 class ExceptionWrapperMiddleware

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace Chialab\FrontendKit\Traits;
 
-use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Routing\Router;
 use Chialab\FrontendKit\Routing\Route\ObjectRoute;
@@ -54,15 +52,11 @@ trait GenericActionsTrait
      */
     public function objects(string $id): Response
     {
-        try {
-            $object = $this->Objects->loadObject($id);
-            $object = $this->Objects->loadFullObject((string)$object->id, $object->type);
-            $this->set(compact('object'));
+        $object = $this->Objects->loadObject($id);
+        $object = $this->Objects->loadFullObject((string)$object->id, $object->type);
+        $this->set(compact('object'));
 
-            return $this->renderFirstTemplate($object->uname, $object->type, 'objects');
-        } catch (RecordNotFoundException $e) {
-            throw new NotFoundException(__('Page not found'), null, $e);
-        }
+        return $this->renderFirstTemplate($object->uname, $object->type, 'objects');
     }
 
     /**
@@ -73,35 +67,31 @@ trait GenericActionsTrait
      */
     public function object(string $uname): Response
     {
-        try {
-            $object = $this->Objects->loadObject($uname);
-            $currentRoute = $this->getRequest()->getParam('_matchedRoute');
-            foreach (Router::routes() as $route) {
-                if (!$route instanceof ObjectRoute || $currentRoute === $route->template) {
-                    continue;
-                }
-
-                $out = $route->match(['_entity' => $object] + $route->defaults, []);
-                if ($out !== false) {
-                    return $this->redirect($out);
-                }
-            }
-            $paths = $this->Publication->getViablePaths($object->id);
-            if (!empty($paths)) {
-                return $this->redirect(['action' => 'fallback', $paths[0]['path']]);
+        $object = $this->Objects->loadObject($uname);
+        $currentRoute = $this->getRequest()->getParam('_matchedRoute');
+        foreach (Router::routes() as $route) {
+            if (!$route instanceof ObjectRoute || $currentRoute === $route->template) {
+                continue;
             }
 
-            $object = $this->Objects->loadFullObject((string)$object->id, $object->type);
-            $this->set(compact('object'));
-
-            $types = collection($object->object_type->getFullInheritanceChain())
-                ->extract('name')
-                ->toList();
-
-            return $this->renderFirstTemplate(...$types);
-        } catch (RecordNotFoundException $e) {
-            throw new NotFoundException(__('Page not found'), null, $e);
+            $out = $route->match(['_entity' => $object] + $route->defaults, []);
+            if ($out !== false) {
+                return $this->redirect($out);
+            }
         }
+        $paths = $this->Publication->getViablePaths($object->id);
+        if (!empty($paths)) {
+            return $this->redirect(['action' => 'fallback', $paths[0]['path']]);
+        }
+
+        $object = $this->Objects->loadFullObject((string)$object->id, $object->type);
+        $this->set(compact('object'));
+
+        $types = collection($object->object_type->getFullInheritanceChain())
+            ->extract('name')
+            ->toList();
+
+        return $this->renderFirstTemplate(...$types);
     }
 
     /**
@@ -112,24 +102,20 @@ trait GenericActionsTrait
      */
     public function fallback(string $path): Response
     {
-        try {
-            $ancestors = $this->Publication->loadObjectPath($path)->toList();
-            $object = array_pop($ancestors);
-            $parent = end($ancestors) ?: null;
+        $ancestors = $this->Publication->loadObjectPath($path)->toList();
+        $object = array_pop($ancestors);
+        $parent = end($ancestors) ?: null;
 
-            if ($object->type === 'folders') {
-                $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $this->Filters->fromQuery());
-                $children = $this->paginate($children->order([], true), ['order' => ['Trees.tree_left']])->toList();
-                $object['children'] = $children;
+        if ($object->type === 'folders') {
+            $children = $this->Objects->loadRelatedObjects($object->uname, 'folders', 'children', $this->Filters->fromQuery());
+            $children = $this->paginate($children->order([], true), ['order' => ['Trees.tree_left']])->toList();
+            $object['children'] = $children;
 
-                $this->set(compact('children'));
-            }
-
-            $this->set(compact('object', 'parent', 'ancestors'));
-
-            return $this->renderFirstTemplate(...$this->getTemplatesToIterate($object, ...array_reverse($ancestors)));
-        } catch (RecordNotFoundException $e) {
-            throw new NotFoundException(__('Page not found'), null, $e);
+            $this->set(compact('children'));
         }
+
+        $this->set(compact('object', 'parent', 'ancestors'));
+
+        return $this->renderFirstTemplate(...$this->getTemplatesToIterate($object, ...array_reverse($ancestors)));
     }
 }


### PR DESCRIPTION
⚠️ BREAKING CHANGE

This PR reverts the (wrong?) choice to automatically throw a `NotFoundException` when default actions catch a `RecordNotFound` exception.

While it may be considered correct to treat that exception as a 404 error instead of using the 500 error code, this is the wrong place to do it since it prevents us from implementing more sophisticated exception handlers in frontends.

We may move those try/catch blocks to the [BEdita App Template](https://github.com/chialab/bedita-app-template).