### PR TITLE
Add excluded relations to object type configs

### DIFF
--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -105,7 +105,12 @@ class ObjectsLoader
         }
 
         if (!isset($options['include'])) {
-            $relations = array_merge($objectType->relations, ['parents', 'translations']);
+            $defaultOptions = $this->getDefaultOptions($objectType);
+            $alwaysInclude = explode(',', Hash::get($defaultOptions, 'include', ''));
+            $alwaysExclude = explode(',', Hash::get($defaultOptions, 'exclude', ''));
+
+            $relations = array_merge($alwaysInclude, $objectType->relations, ['parents', 'translations']);
+            $relations = array_diff($relations, $alwaysExclude);
             $options['include'] = implode(',', $relations);
         } else {
             $relations = explode(',', $options['include']);

--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -105,12 +105,10 @@ class ObjectsLoader
         }
 
         if (!isset($options['include'])) {
-            $defaultOptions = $this->getDefaultOptions($objectType);
-            $alwaysInclude = explode(',', Hash::get($defaultOptions, 'include', ''));
-            $alwaysExclude = explode(',', Hash::get($defaultOptions, 'exclude', ''));
+            $exclude = explode(',', Hash::get($this->getDefaultOptions($objectType), 'exclude', ''));
 
-            $relations = array_merge($alwaysInclude, $objectType->relations, ['parents', 'translations']);
-            $relations = array_diff($relations, $alwaysExclude);
+            $relations = array_merge($objectType->relations, ['parents', 'translations']);
+            $relations = array_diff($relations, $exclude);
             $options['include'] = implode(',', $relations);
         } else {
             $relations = explode(',', $options['include']);


### PR DESCRIPTION
This PR let the developer to exclude some relations when using the `loadFullObject` method.