### PR TITLE
Object action should check for compatible locale routes only

### DIFF
--- a/src/Routing/Route/ObjectRoute.php
+++ b/src/Routing/Route/ObjectRoute.php
@@ -65,6 +65,9 @@ class ObjectRoute extends DashedRoute
         if (!isset($entity)) {
             return parent::match($url, $context);
         }
+        if (empty($url['locale']) === in_array('locale', $this->keys)) {
+            return false;
+        }
         $this->checkEntity($entity);
         if ($this->checkFilters($entity) === false) {
             return false;

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -165,10 +165,6 @@ trait GenericActionsTrait
                 continue;
             }
 
-            if (empty($locale) === in_array('locale', $route->keys)) {
-                continue;
-            }
-
             $out = $route->match(['_entity' => $entity] + $route->defaults + $params, []);
             if ($out !== false) {
                 return $this->redirect($out);


### PR DESCRIPTION
This PR prevents a request with `locale` param to fallback to `ObjectRoute`s that do not handle that param.