### PR TITLE
Add middleware for trusting proxies by subnet rather than single addresses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "wyrihaximus/twig-view": "^4.3",
         "chialab/rna-cakephp": "^0.2.1",
         "bedita/i18n": "^3.2",
-        "cakephp/authentication": "^1.0"
+        "cakephp/authentication": "^1.0",
+        "chialab/ip": "^1.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",

--- a/src/Middleware/TrustedProxiesMiddleware.php
+++ b/src/Middleware/TrustedProxiesMiddleware.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Middleware;
+
+use Cake\Http\ServerRequest;
+use Chialab\Ip\Address;
+use Chialab\Ip\Subnet;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Traversable;
+
+/**
+ * Middleware to set trusted proxies on the incoming request, thus reliably reading actual client IP.
+ */
+class TrustedProxiesMiddleware
+{
+    /**
+     * List of trusted proxies.
+     *
+     * @var string[]
+     */
+    protected array $trustedProxies = [];
+
+    /**
+     * Compiled list of subnets.
+     *
+     * @var \Chialab\Ip\Subnet[]|null
+     */
+    protected ?array $subnets;
+
+    /**
+     * Middleware constructor.
+     *
+     * @param string ...$trustedProxies List of trusted proxies, expressed as IP addresses or subnets (in CIDR block notation).
+     * @codeCoverageIgnore
+     */
+    public function __construct(string ...$trustedProxies)
+    {
+        $this->trustedProxies = $trustedProxies;
+    }
+
+    /**
+     * Iterate through trusted proxies, compiled as {@see \Chialab\Ip\Subnet} objects.
+     *
+     * @return \Chialab\Ip\Subnet[]
+     */
+    protected function compile(): array
+    {
+        if (isset($this->subnets)) {
+            return $this->subnets;
+        }
+
+        $subnets = [];
+        foreach ($this->trustedProxies as $trustedProxy) {
+            if (strpos($trustedProxy, '/') !== false) {
+                // If the string contains a forward slash, we assume it's in CIDR block notation.
+                $subnets[] = Subnet::parse($trustedProxy);
+
+                continue;
+            }
+
+            // Otherwise, we assume it is a single IP address, and we identify an address with the subnet consisting of that address alone.
+            $address = Address::parse($trustedProxy);
+            $subnets[] = new Subnet($address, $address->getProtocolVersion()->getBitsLength());
+        }
+
+        return $this->subnets = $subnets;
+    }
+
+    /**
+     * Check if an address is trusted.
+     *
+     * @param string $remoteAddress Remote address.
+     * @return bool
+     */
+    protected function isTrusted(string $remoteAddress): bool
+    {
+        try {
+            $address = Address::parse($remoteAddress);
+        } catch (\InvalidArgumentException $e) {
+            return false;
+        }
+
+        foreach ($this->compile() as $subnet) {
+            if ($subnet->contains($address)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Invoke method.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next Callback to invoke the next middleware.
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
+    {
+        if (!$request instanceof ServerRequest || empty($this->trustedProxies)) {
+            return $next($request, $response);
+        }
+
+        while (true) {
+            $remoteAddress = $request->clientIp();
+            if (!$this->isTrusted($remoteAddress)) {
+                break;
+            }
+
+            $request->trustProxy = true;
+            $request->setTrustedProxies(array_merge($request->getTrustedProxies(), [$remoteAddress]));
+        }
+
+        return $next($request, $response);
+    }
+}

--- a/tests/TestCase/Middleware/TrustedProxiesMiddlewareTest.php
+++ b/tests/TestCase/Middleware/TrustedProxiesMiddlewareTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Chialab\FrontendKit\Test\TestCase\Middleware;
+
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Chialab\FrontendKit\Middleware\TrustedProxiesMiddleware;
+use Laminas\Diactoros\ServerRequest as DiactorosServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Test {@see \Chialab\FrontendKit\Middleware\TrustedProxiesMiddleware}.
+ *
+ * @covers \Chialab\FrontendKit\Middleware\TrustedProxiesMiddleware
+ */
+class TrustedProxiesMiddlewareTest extends TestCase
+{
+    /**
+     * Data provider for {@see TrustedProxiesMiddlewareTest::testInvoke()} test case.
+     *
+     * @return array{string|null, string[]|null, \Chialab\FrontendKit\Middleware\TrustedProxiesMiddleware, \Psr\Http\Message\ServerRequestInterface}[]
+     */
+    public function invokeProvider(): array
+    {
+        $requestFactory = fn (string $remoteAddr, string $xForwardedFor): ServerRequest => new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => $remoteAddr,
+                'HTTP_X_FORWARDED_FOR' => $xForwardedFor,
+            ],
+        ]);
+
+        return [
+            'not a Cake request' => [null, null, new TrustedProxiesMiddleware('127.0.0.1'), new DiactorosServerRequest()],
+            'no trusted proxies' => ['127.0.0.1', [], new TrustedProxiesMiddleware(), $requestFactory('127.0.0.1', '10.0.1.1, 192.168.1.1')],
+            'trusted proxies' => ['192.168.1.1', ['127.0.0.1'], new TrustedProxiesMiddleware('127.0.0.1'), $requestFactory('127.0.0.1', '10.0.1.1, 192.168.1.1')],
+            'multiple trusted proxies' => ['10.0.1.1', ['127.0.0.1', '192.168.1.1'], new TrustedProxiesMiddleware('127.0.0.1', '192.168.0.0/16'), $requestFactory('127.0.0.1', '10.0.1.1, 192.168.1.1')],
+            'invalid address' => ['not-an-ip-address', ['127.0.0.1'], new TrustedProxiesMiddleware('127.0.0.1', '192.168.0.0/16'), $requestFactory('127.0.0.1', '10.0.1.1, 192.168.1.1, not-an-ip-address')],
+        ];
+    }
+
+    /**
+     * Test {@see TrustedProxiesMiddleware}.
+     *
+     * @param string|null $expectedClientIp Expected client IP after middleware execution.
+     * @param string|null $expectedTrustedProxies Expected trusted proxies list after middleware execution.
+     * @param \Chialab\FrontendKit\Middleware\TrustedProxiesMiddleware $middleware Middleware instance.
+     * @param \Psr\Http\Message\ServerRequestInterface $request Incoming request.
+     * @return void
+     * @dataProvider invokeProvider()
+     */
+    public function testInvoke(?string $expectedClientIp, ?array $expectedTrustedProxies, TrustedProxiesMiddleware $middleware, ServerRequestInterface $request): void
+    {
+        $response = new Response();
+        $invoked = 0;
+        $next = function (ServerRequestInterface $req, ResponseInterface $res) use ($response, $expectedClientIp, $expectedTrustedProxies, &$invoked): ResponseInterface {
+            $invoked++;
+            static::assertSame($response, $res, 'It should not manipulate response object');
+            if ($expectedClientIp !== null) {
+                static::assertInstanceOf(ServerRequest::class, $req);
+            }
+            if ($req instanceof ServerRequest) {
+                static::assertSame($expectedClientIp, $req->clientIp());
+                static::assertEquals($expectedTrustedProxies, $req->getTrustedProxies());
+            }
+
+            return $res;
+        };
+
+        $res = $middleware($request, $response, $next);
+        static::assertSame($response, $res);
+        static::assertSame(1, $invoked);
+    }
+}


### PR DESCRIPTION
This MR adds a new `TrustedProxiesMiddleware` that can be used to trust middleware whose IP address is not known aforehand, and can only be trusted by subnet.

## Example

```php
$mw = new TrustedProxiesMiddleware(
    '127.0.0.1', // Trust a single address...
    '192.168.0.0/16', // ...or trust a whole subnet.
);

// Add the middleware to the Application.
```