### PR TITLE
Handle provider thumbnail

### DIFF
--- a/src/View/Helper/PosterHelper.php
+++ b/src/View/Helper/PosterHelper.php
@@ -136,6 +136,10 @@ class PosterHelper extends Helper
      */
     public function exists(?ObjectEntity $object, array $options = []): bool
     {
+        if ($object->has('provider_thumbnail')) {
+            return true;
+        }
+
         foreach ($this->candidates($object, $options) as $media) {
             if ($media->has('media_url')) {
                 return true;
@@ -199,6 +203,10 @@ class PosterHelper extends Helper
      */
     public function url(?ObjectEntity $object, $thumbOptions = 'default', array $posterOptions = []): ?string
     {
+        if ($object->has('provider_thumbnail')) {
+            return $object->get('provider_thumbnail');
+        }
+
         $fallbackStatic = filter_var(Hash::get($posterOptions, 'fallbackStatic', true), FILTER_VALIDATE_BOOL);
         $thumbFallbackOptions = $posterOptions;
         $thumbFallbackOptions['fallbackStatic'] = false;

--- a/tests/TestCase/View/Helper/PosterHelperTest.php
+++ b/tests/TestCase/View/Helper/PosterHelperTest.php
@@ -62,6 +62,13 @@ class PosterHelperTest extends TestCase
         ]);
     }
 
+    protected function createVideo(): Media
+    {
+        return new Media([
+            'type' => 'videos',
+        ]);
+    }
+
     protected function createStream(int $width, int $height): Stream
     {
         return new Stream([
@@ -119,5 +126,35 @@ class PosterHelperTest extends TestCase
 
         $orientation = $this->Poster->orientation($object);
         $this->assertSame('landscape', $orientation);
+    }
+
+    /**
+     * Test {@see PosterHelper::exists()}.
+     *
+     * @return void
+     *
+     * @covers ::exists()
+     */
+    public function testExistsWithProviderThumbnail()
+    {
+        $object = $this->createVideo();
+        $object->set('provider_thumbnail', 'https://www.bedita.com/favicon.png');
+
+        $this->assertTrue($this->Poster->exists($object));
+    }
+
+    /**
+     * Test {@see PosterHelper::url()}.
+     *
+     * @return void
+     *
+     * @covers ::url()
+     */
+    public function testUrlWithProviderThumbnail()
+    {
+        $object = $this->createVideo();
+        $object->set('provider_thumbnail', 'https://www.bedita.com/favicon.png');
+
+        $this->assertSame('https://www.bedita.com/favicon.png', $this->Poster->url($object));
     }
 }


### PR DESCRIPTION
This PR instructs the `PosterHelper` to use the `provider_thumbnail` field for `Media` objects, when available.