### PR TITLE
Upgrade fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /composer.lock
 /phpunit.xml
 /vendor

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,12 +15,8 @@
       <directory>tests/TestCase/</directory>
     </testsuite>
   </testsuites>
-  <!-- Setup a listener for fixtures -->
-  <listeners>
-    <listener class="\Cake\TestSuite\Fixture\FixtureInjector">
-      <arguments>
-        <object class="\Cake\TestSuite\Fixture\FixtureManager"/>
-      </arguments>
-    </listener>
-  </listeners>
+  <!-- Setup extension for fixtures -->
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension"/>
+    </extensions>
 </phpunit>

--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -100,7 +100,7 @@ class ObjectsLoader
      * @param array|null $hydrate Override auto-hydrate options (e.g.: `['poster' => 2]`).
      * @return \BEdita\Core\Model\Entity\ObjectEntity
      */
-    public function loadFullObject(string $id, string|null $type = null, array|null $options = null, array|null $hydrate = null): ObjectEntity
+    public function loadFullObject(string|int $id, string|null $type = null, array|null $options = null, array|null $hydrate = null): ObjectEntity
     {
         // Normalize ID, get type.
         $id = $this->Objects->getId($id);

--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -88,7 +88,7 @@ trait GenericActionsTrait
             }
             $order = str_starts_with($order, '-') ? [$type => 'DESC'] : [$type => 'ASC'];
         } else {
-            $order = ['Trees.tree_left'];
+            $order = ['Trees.tree_left' => 'ASC'];
         }
 
         $sortAllowlist = $this->paginate['sortableFields'] ?? (array)$this->request->getQuery('sort');

--- a/tests/Fixture/ObjectTypesFixture.php
+++ b/tests/Fixture/ObjectTypesFixture.php
@@ -10,28 +10,25 @@ class ObjectTypesFixture extends BEObjectTypesFixture
 {
     public function init(): void
     {
-        array_push(
-            $this->records,
-            // 11
-            [
-                'singular' => 'image',
-                'name' => 'images',
-                'is_abstract' => false,
-                'parent_id' => 8,
-                'tree_left' => 17,
-                'tree_right' => 18,
-                'description' => null,
-                'plugin' => 'BEdita/Core',
-                'model' => 'Media',
-                'associations' => '["Streams"]',
-                'created' => '2017-11-10 09:27:23',
-                'modified' => '2017-11-10 09:27:23',
-                'enabled' => true,
-                'core_type' => true,
-                'translation_rules' => null,
-                'is_translatable' => true,
-            ],
-        );
+        // 11
+        $this->records[] = [
+            'singular' => 'image',
+            'name' => 'images',
+            'is_abstract' => false,
+            'parent_id' => 8,
+            'tree_left' => 17,
+            'tree_right' => 18,
+            'description' => null,
+            'plugin' => 'BEdita/Core',
+            'model' => 'Media',
+            'associations' => ['Streams'],
+            'created' => '2017-11-10 09:27:23',
+            'modified' => '2017-11-10 09:27:23',
+            'enabled' => true,
+            'core_type' => true,
+            'translation_rules' => null,
+            'is_translatable' => true,
+        ];
 
         parent::init();
     }

--- a/tests/Fixture/ObjectTypesFixture.php
+++ b/tests/Fixture/ObjectTypesFixture.php
@@ -28,6 +28,8 @@ class ObjectTypesFixture extends BEObjectTypesFixture
                 'modified' => '2017-11-10 09:27:23',
                 'enabled' => true,
                 'core_type' => true,
+                'translation_rules' => null,
+                'is_translatable' => true,
             ],
         );
 

--- a/tests/Fixture/TreesFixture.php
+++ b/tests/Fixture/TreesFixture.php
@@ -33,7 +33,7 @@ class TreesFixture extends BETreesFixture
         parent::init();
     }
 
-    private function transformBranch($branch, &$records = null, $parent = null, &$count = 0)
+    private function transformBranch($branch, &$records = null, $parent = null, &$count = 0): array
     {
         if ($records === null) {
             $records = [];

--- a/tests/TestCase/Trait/GenericActionsTraitTest.php
+++ b/tests/TestCase/Trait/GenericActionsTraitTest.php
@@ -141,7 +141,7 @@ class GenericActionsTraitTest extends TestCase
     public function testFallback($url, $objectUname, $children, $related, $parentUname, $ancestorUnames, $body)
     {
         [$path, $filters] = $url;
-        $this->controller->request = $this->controller->getRequest()->withQueryParams($filters);
+        $this->controller->setRequest($this->controller->getRequest()->withQueryParams($filters));
 
         $response = $this->controller->fallback($path);
 
@@ -178,7 +178,7 @@ class GenericActionsTraitTest extends TestCase
         }
 
         // assert the parent has been correctly loaded
-        static::assertSame($parentUname, $parent ? $parent->uname : null);
+        static::assertSame($parentUname, $parent?->uname);
 
         // assert the ancestors have been correctly loaded
         static::assertSame($ancestorUnames, array_map(fn (Folder $ancestor): string => $ancestor->uname, $ancestors));

--- a/tests/TestCase/Trait/GenericActionsTraitTest.php
+++ b/tests/TestCase/Trait/GenericActionsTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Chialab\FrontendKit\Test\TestCase\Controller\Component;
+namespace Chialab\FrontendKit\Test\TestCase\Trait;
 
 use BEdita\Core\Model\Entity\Folder;
 use Cake\Http\Response;

--- a/tests/TestCase/Trait/RenderTraitTest.php
+++ b/tests/TestCase/Trait/RenderTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Chialab\FrontendKit\Test\TestCase\Controller\Component;
+namespace Chialab\FrontendKit\Test\TestCase\Trait;
 
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,7 @@ use Cake\Routing\Router;
 use Cake\Utility\Security;
 use Chialab\FrontendKit\Test\TestApp\Application;
 use Chialab\FrontendKit\Test\TestApp\Filesystem\Adapter\NullAdapter;
+use Migrations\TestSuite\Migrator;
 
 $findRoot = function ($root) {
     do {
@@ -105,3 +106,7 @@ TableRegistry::getTableLocator()->clear();
 Cache::clear('_cake_core_');
 Cache::clear('_cake_model_');
 Cache::clear('_bedita_object_types_');
+
+// Run migrations
+$migrator = new Migrator();
+$migrator->run(['plugin' => 'BEdita/Core']);


### PR DESCRIPTION
This PR upgrades fixtures for CakePHP 4.3+ (see [here](https://book.cakephp.org/4/en/appendices/fixture-upgrade.html#fixture-upgrade)), which has been adopted by BEdita 5.