### PR TITLE
Whole day approximated to the minute

### DIFF
--- a/src/Command/TwigSyntaxCheckCommand.php
+++ b/src/Command/TwigSyntaxCheckCommand.php
@@ -24,7 +24,7 @@ use Twig\Source;
 class TwigSyntaxCheckCommand extends Command
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public static function defaultName(): string
     {
@@ -32,7 +32,7 @@ class TwigSyntaxCheckCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
@@ -50,7 +50,7 @@ class TwigSyntaxCheckCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function execute(Arguments $args, ConsoleIo $io): int
     {
@@ -114,7 +114,7 @@ class TwigSyntaxCheckCommand extends Command
      * List templates within a path.
      *
      * @param string $path Path to search templates into.
-     * @param string[] $extensions Extensions to filter by.
+     * @param array<string> $extensions Extensions to filter by.
      * @return \Iterator<string, string>
      */
     protected static function templatesIterator(string $path, array $extensions): Iterator
@@ -143,7 +143,7 @@ class TwigSyntaxCheckCommand extends Command
      * Filter out ignored paths from an iterator.
      *
      * @param \Iterator<array-key, string> $paths Paths iterator.
-     * @param string[] $ignoredPaths List of ignored paths.
+     * @param array<string> $ignoredPaths List of ignored paths.
      * @return \Iterator<array-key, string>
      */
     protected static function filterIgnoredPaths(Iterator $paths, array $ignoredPaths): Iterator

--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -86,7 +86,7 @@ class DateRangesHelper extends Helper
     protected function getFormats(FrozenTime $start, FrozenTime $end): Generator
     {
         if ($end->isSameDay($start)) {
-            if ($start->equals($start->startOfDay()) && $end->equals($end->endOfDay())) {
+            if ($start->second(0)->equals($start->startOfDay()) && $end->second(59)->equals($end->endOfDay())) {
                 yield 'wholeDay';
             }
             yield 'sameDay';

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -79,6 +79,11 @@ class DateRangesHelperTest extends TestCase
                  new FrozenTime('2021-09-09T00:00:00'),
                  new FrozenTime('2021-09-09T23:59:59'),
             ],
+            'whole day, with approximation to the whole minute ' => [
+                '9 settembre 2021',
+                new FrozenTime('2021-09-09T00:00:01'),
+                new FrozenTime('2021-09-09T23:59:00'),
+            ],
             'time range within same day' => [
                 '9 settembre 2021, dalle 18:15 alle 19:00',
                 new FrozenTime('2021-09-09T18:15:00'),


### PR DESCRIPTION
This PR fixes an issue where some times of day such as 23:59:00 wouldn't count as "end of day". This might happen if the input in the admin UI doesn't have seconds-level granularity.