### PR TITLE
When localizing dates using ICU, use `y` for year instead of `Y`

### DIFF
--- a/src/View/Helper/DateRangesHelper.php
+++ b/src/View/Helper/DateRangesHelper.php
@@ -25,8 +25,8 @@ class DateRangesHelper extends Helper
         'wholeDay' => '{0,date,long}',
         'sameDay' => '{0,date,long}, dalle {0,time,short} alle {1,time,short}',
         'sameMonth' => 'dal {0,date,d} al {1,date,long}',
-        'sameYear' => 'dal {0,date,d MMM} al {1,date,d MMM Y}',
-        'other' => 'dal {0,date,d MMM Y} al {1,date,d MMM Y}',
+        'sameYear' => 'dal {0,date,d MMM} al {1,date,d MMM y}',
+        'other' => 'dal {0,date,d MMM y} al {1,date,d MMM y}',
     ];
 
     /**

--- a/tests/TestCase/View/Helper/DateRangesHelperTest.php
+++ b/tests/TestCase/View/Helper/DateRangesHelperTest.php
@@ -105,6 +105,17 @@ class DateRangesHelperTest extends TestCase
                 new FrozenTime('2019-10-01T18:15:00'),
                 new FrozenTime('2020-10-16T19:00:00'),
             ],
+
+            'end date is in the first week of the next year (same year)' => [
+                'dal 1 gen al 31 dic 2024',
+                new FrozenTime('2024-01-01T00:00:00'),
+                new FrozenTime('2024-12-31T00:00:00'),
+            ],
+            'end date is in the first week of the next year (different year)' => [
+                'dal 18 ott 2023 al 31 dic 2024',
+                new FrozenTime('2023-10-18T14:59:34'),
+                new FrozenTime('2024-12-31T00:00:00'),
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR fixes a nasty issue with dates close to the end of the year. If the date is in the first week of the next year (i.e. the first week that has at least four days in the next year), the displayed year would have been incorrect.

Likewise a similar issue could arise for dates close to the beginning of the year, which might be in the last week of the previous year.

This happened for example for 2024-12-30 and 2024-12-31, as the week starting on 2024-12-30 (or 2024-12-29, for locales where week starts on Sunday) is the first week of year 2025.

<img width="342" alt="calendar for December 2024" src="https://github.com/chialab/bedita-frontend-kit/assets/7108146/1207ffde-fc22-4deb-ba79-b4dd517621f4">

See ICU docs for further info: https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table

- `y` is for the year of the date
- `Y` is for the year of the "week of Year"
