### PR TITLE
Use translated categories labels

### DIFF
--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -439,6 +439,15 @@ class ObjectsLoader
             return $object;
         }
 
+        if (!empty($object->get('categories'))) {
+            foreach ($object->categories as &$category) {
+                if (array_key_exists($lang, $category->labels)) {
+                    $category->label = $category->labels[$lang];
+                }
+            }
+            unset($category);
+        }
+
         /** @var \BEdita\Core\Model\Entity\Translation|null $requestedTranslation */
         $requestedTranslation = collection($object->translations ?? [])
             ->filter(fn (Translation $tr): bool => $tr->lang === $lang)
@@ -450,6 +459,7 @@ class ObjectsLoader
         $originalFields = [
             'lang' => $object->lang,
         ];
+
         $object->lang = $requestedTranslation->lang;
         $object->setDirty('lang', false);
 


### PR DESCRIPTION
This PR set the `label` field of a category using current locale, if set. All the `labels` are preserved on the original object.