### PR TITLE
Add public methods to re-configure ObjectLoader

### DIFF
--- a/src/Controller/Component/ObjectsComponent.php
+++ b/src/Controller/Component/ObjectsComponent.php
@@ -60,6 +60,28 @@ class ObjectsComponent extends Component
     }
 
     /**
+     * Set object types configuration.
+     *
+     * @param array $objectTypesConfig Object types configuration.
+     * @return void
+     */
+    public function setObjectTypesConfig(array $objectTypesConfig): void
+    {
+        $this->getLoader()->setObjectTypesConfig($objectTypesConfig);
+    }
+
+    /**
+     * Set auto-hydrate associations.
+     *
+     * @param array $autoHydrateAssociations Auto-hydrate associations.
+     * @return void
+     */
+    public function setAutoHydrateAssociations(array $autoHydrateAssociations): void
+    {
+        $this->getLoader()->setAutoHydrateAssociations($autoHydrateAssociations);
+    }
+
+    /**
      * Fetch an object by its ID or uname.
      *
      * @param string|int $id Object ID or uname.

--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -67,11 +67,33 @@ class ObjectsLoader
      */
     public function __construct(array $objectTypesConfig = [], array $autoHydrateAssociations = [])
     {
-        $this->objectTypesConfig = $objectTypesConfig;
-        $this->autoHydrateAssociations = $autoHydrateAssociations;
+        $this->setObjectTypesConfig($objectTypesConfig);
+        $this->setAutoHydrateAssociations($autoHydrateAssociations);
 
         $this->ObjectTypes = $this->fetchTable('BEdita/Core.ObjectTypes');
         $this->Objects = $this->fetchTable('BEdita/Core.Objects');
+    }
+
+    /**
+     * Set object types configuration.
+     *
+     * @param array $objectTypesConfig Object types configuration.
+     * @return void
+     */
+    public function setObjectTypesConfig(array $objectTypesConfig): void
+    {
+        $this->objectTypesConfig = $objectTypesConfig;
+    }
+
+    /**
+     * Set auto-hydrate associations.
+     *
+     * @param array $autoHydrateAssociations Auto-hydrate associations.
+     * @return void
+     */
+    public function setAutoHydrateAssociations(array $autoHydrateAssociations): void
+    {
+        $this->autoHydrateAssociations = $autoHydrateAssociations;
     }
 
     /**


### PR DESCRIPTION
This methods can be used in a controller to change the default `ObjectsLoader` configuration.

Example:
```php
public function customRoute(): Response
{
    /**
     * @var \Chialab\FrontendKit\Controller\Component\ObjectsComponent $component
     */
    $component = $this->components->get('Objects');
    $component->setObjectTypesConfig([
        'objects' => ['include' => 'poster|1,see_also'],
    ]);

    return $this->fallback('custom-route');
}
```