### PR TITLE
MediaUrl when stream is a gif

### DIFF
--- a/src/View/Helper/ThumbHelper.php
+++ b/src/View/Helper/ThumbHelper.php
@@ -57,14 +57,6 @@ class ThumbHelper extends Helper
      */
     public function url(ObjectEntity|null $object, array|string $thumbOptions = 'default', array $fallbackOptions = []): string|null
     {
-        if (
-            $object !== null &&
-            $object instanceof Media &&
-            $this->Media->getStream($object)?->mime_type === 'image/gif'
-        ) {
-            return $object->get('media_url');
-        }
-
         $allowPending = filter_var(Hash::get($fallbackOptions, 'allowPending', false), FILTER_VALIDATE_BOOL);
         $fallbackOriginal = filter_var(Hash::get($fallbackOptions, 'fallbackOriginal', true), FILTER_VALIDATE_BOOL);
         $fallbackStatic = filter_var(Hash::get($fallbackOptions, 'fallbackStatic', true), FILTER_VALIDATE_BOOL);
@@ -79,6 +71,10 @@ class ThumbHelper extends Helper
 
         $stream = $this->Media->getStream($media);
         if ($stream !== null) {
+            if ($stream?->mime_type === 'image/gif') {
+                return $media->get('media_url');
+            }
+
             $res = Thumbnail::get($stream, $thumbOptions);
             if (!empty($res['url']) && (!empty($res['ready']) || $allowPending)) {
                 return $res['url'];

--- a/src/View/Helper/ThumbHelper.php
+++ b/src/View/Helper/ThumbHelper.php
@@ -57,6 +57,14 @@ class ThumbHelper extends Helper
      */
     public function url(ObjectEntity|null $object, array|string $thumbOptions = 'default', array $fallbackOptions = []): string|null
     {
+        if (
+            $object !== null &&
+            $object instanceof Media &&
+            $this->Media->getStream($object)?->mime_type === 'image/gif'
+        ) {
+            return $object->get('media_url');
+        }
+
         $allowPending = filter_var(Hash::get($fallbackOptions, 'allowPending', false), FILTER_VALIDATE_BOOL);
         $fallbackOriginal = filter_var(Hash::get($fallbackOptions, 'fallbackOriginal', true), FILTER_VALIDATE_BOOL);
         $fallbackStatic = filter_var(Hash::get($fallbackOptions, 'fallbackStatic', true), FILTER_VALIDATE_BOOL);


### PR DESCRIPTION
This pull request introduces a new condition in the `url` method of the `ThumbHelper` class to handle GIF images specifically. The most important change is the addition of a check for GIF images and returning the media URL if the condition is met.

Enhancements to GIF image handling:

* [`src/View/Helper/ThumbHelper.php`](diffhunk://#diff-ab83836b07fe330d98a7881f5140f40cbc5ea91464ea258fb99d6dad53da7830R60-R67): Added a condition to check if the object is an instance of `Media` and if its MIME type is `image/gif`, returning the media URL in such cases.