### PR TITLE
Fix: sortableFields settings

### DIFF
--- a/src/Traits/GenericActionsTrait.php
+++ b/src/Traits/GenericActionsTrait.php
@@ -95,13 +95,13 @@ trait GenericActionsTrait
 
         $settings = Hash::merge($this->paginate, [
             'order' => $order,
-            'sortableFields' => array_merge($this->paginate['sortableFields'] ?? (array)$this->request->getQuery('sort'), array_keys($order)),
+            'sortableFields' => array_filter(array_merge($this->paginate['sortableFields'] ?? (array)$this->request->getQuery('sort'), array_keys($order))),
         ]);
         if (isset($settings['Children'])) {
             $settings = Hash::merge($settings, [
                 'Children' => [
                     'order' => $order,
-                    'sortableFields' => array_merge($this->paginate['Children']['sortableFields'] ?? (array)$this->request->getQuery('sort'), array_keys($order)),
+                    'sortableFields' => array_filter(array_merge($this->paginate['Children']['sortableFields'] ?? (array)$this->request->getQuery('sort'), array_keys($order))),
                 ],
             ]);
         }


### PR DESCRIPTION
This pull request includes a minor change to the `src/Traits/GenericActionsTrait.php` file. The change involves filtering the `sortableFields` array to remove any empty values before merging it with the existing sortable fields and order keys.

* [`src/Traits/GenericActionsTrait.php`](diffhunk://#diff-91a357510de6ea4726aa62b29ae781c9f393e92c95b6dc904132eda4d2f01111L98-R104): Updated the `loadFilteredChildren` method to use `array_filter` on `sortableFields` in two places to ensure no empty values are included.