### PR TITLE
feat: CakePHP 4.5 and read connection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: 'echo "COMPOSER_CACHE_DIR=$(composer global config cache-dir)" >> $GITHUB_OUTPUT'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
         with:
-          path: '${{ steps.cachedir.outputs.path }}'
+          path: '${{ steps.cachedir.outputs.COMPOSER_CACHE_DIR }}'
           key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ github.job }}-
@@ -65,12 +65,12 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: 'echo "COMPOSER_CACHE_DIR=$(composer global config cache-dir)" >> $GITHUB_OUTPUT'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
         with:
-          path: '${{ steps.cachedir.outputs.path }}'
+          path: '${{ steps.cachedir.outputs.COMPOSER_CACHE_DIR }}'
           key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ github.job }}-
@@ -94,9 +94,10 @@ jobs:
         php:
           - '8.1'
           - '8.2'
+          - '8.3'
         db:
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
 
     env:
       PHP_VERSION: '${{ matrix.php }}'
@@ -135,12 +136,12 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: 'echo "COMPOSER_CACHE_DIR=$(composer global config cache-dir)" >> $GITHUB_OUTPUT'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
         with:
-          path: '${{ steps.cachedir.outputs.path }}'
+          path: '${{ steps.cachedir.outputs.COMPOSER_CACHE_DIR }}'
           key: "composer-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php }}-

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-json": "*",
         "bedita/core": "^5.14.0",
         "bedita/i18n": "^4.0",
-        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp": "^4.5",
         "cakephp/authentication": "^2.0",
         "cakephp/twig-view": "^1.3",
         "chialab/ip": "^1.0"

--- a/src/Model/ObjectsLoader.php
+++ b/src/Model/ObjectsLoader.php
@@ -19,6 +19,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -296,6 +297,10 @@ class ObjectsLoader
         $action = new ListObjectsAction(compact('objectType', 'table'));
         /** @var \Cake\ORM\Query $query */
         $query = $action(static::includeTranslations($contain) ? compact('filter', 'contain') : compact('filter', 'lang', 'contain'));
+        if ($query instanceof SelectQuery) {
+            $query->useReadRole();
+        }
+
         /** @var \Cake\ORM\Table $table */
         $table = $query->getRepository();
 
@@ -338,6 +343,9 @@ class ObjectsLoader
 
         /** @var \Cake\ORM\Query $query */
         $query = $action(compact('primaryKey', 'filter', 'lang'));
+        if ($query instanceof SelectQuery) {
+            $query->useReadRole();
+        }
 
         return $query->formatResults(function (iterable $results) use ($contain, $depth, $hydrate, $table, $lang): iterable {
             $objects = $this->toConcreteTypes($results, $depth + 1);

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -12,6 +12,7 @@ use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 
 /**
  * Class TreeLoader.
@@ -166,6 +167,10 @@ class TreeLoader
                         new IdentifierExpression($this->Trees->ParentNode->aliasField('object_id')),
                     ),
             );
+
+        if ($query instanceof SelectQuery) {
+            $query->useReadRole();
+        }
 
         return $query->disableHydration();
     }

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -7,12 +7,13 @@ use BEdita\Core\Model\Entity\Folder;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Table\TreesTable;
 use Cake\Collection\CollectionInterface;
-use Cake\Database\Expression\ComparisonExpression;
+use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Query\SelectQuery;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
-use Cake\ORM\Query\SelectQuery;
 
 /**
  * Class TreeLoader.
@@ -61,10 +62,11 @@ class TreeLoader
         $leaf = $this->loader->loadObject(array_pop($parts), 'objects', [], []);
 
         $found = $this->getObjectPaths($leaf->id, $relativeTo)
-            ->having(compact('path'), ['path' => 'string'])
-            ->firstOrFail();
+            ->andWhere(['paths.path' => $path]);
 
-        $ids = explode(',', $found['path_ids']);
+        $found = $found->firstOrFail();
+
+        $ids = array_reverse(json_decode($found['reverse_path_ids']));
         array_pop($ids);
 
         if (empty($ids)) {
@@ -91,9 +93,17 @@ class TreeLoader
     {
         $query = $this->getObjectPaths($id, $relativeTo);
         if ($via !== null) {
-            $query = $query->having(new FunctionExpression('BIT_OR', [
-                new ComparisonExpression($this->Trees->ParentNode->aliasField('object_id'), $via, 'integer', '='),
-            ]));
+            $query = $query->andWhere(
+                fn(QueryExpression $exp): QueryExpression => $exp->add(new FunctionExpression(
+                    'JSON_CONTAINS',
+                    [
+                        new IdentifierExpression('paths.reverse_path_ids'),
+                        $via,
+                        '$',
+                    ],
+                    ['json', 'json', 'string'],
+                )),
+            );
         }
 
         return $query->all()->toList();
@@ -106,73 +116,65 @@ class TreeLoader
      * @param int|null $relativeTo Object ID relative to which paths should be computed.
      * @return \Cake\ORM\Query
      */
-    protected function getObjectPaths(int $id, int|null $relativeTo = null): Query
+    protected function getObjectPaths(int $id, int|null $relativeTo = null): Query\SelectQuery
     {
-        $query = $this->Trees->find()
-            ->select([$this->Trees->aliasField('canonical')])
-            ->where([$this->Trees->aliasField('object_id') => $id])
-            ->group([$this->Trees->aliasField('id'), $this->Trees->aliasField('canonical')])
-            ->orderDesc($this->Trees->aliasField('canonical'));
+        return $this->Trees->find()
+            ->useReadRole()
+            ->disableHydration()
+            ->with(
+                fn(CommonTableExpression $cte, SelectQuery $query): CommonTableExpression => $cte
+                    ->recursive()
+                    ->name('paths')
+                    ->field(['canonical', 'reverse_path_ids', 'path', 'parent_id'])
+                    ->query(
+                        $this->Trees->find()
+                            ->select([
+                                $this->Trees->aliasField('canonical'),
+                                new FunctionExpression('JSON_ARRAY', [
+                                    new IdentifierExpression($this->Trees->aliasField('object_id')),
+                                ]),
+                                $this->Trees->Objects->aliasField('uname'),
+                                $this->Trees->aliasField('parent_id'),
+                            ])
+                            ->innerJoinWith($this->Trees->Objects->getName())
+                            ->where([$this->Trees->aliasField('object_id') => $id])
 
-        // Join with parent nodes, up to the requested node.
-        $exp = $query->newExpr()
-            ->eq(
-                new IdentifierExpression($this->Trees->ParentNode->aliasField('root_id')),
-                new IdentifierExpression($this->Trees->aliasField('root_id')),
-            )
-            ->lte(
-                new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_left')),
-                new IdentifierExpression($this->Trees->aliasField('tree_left')),
-            )
-            ->gte(
-                new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_right')),
-                new IdentifierExpression($this->Trees->aliasField('tree_right')),
-            );
-        if ($relativeTo !== null) {
-            $exp = $exp
-                ->gt(
-                    new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_left')),
-                    $this->Trees->find()
-                        ->select([$this->Trees->aliasField('tree_left')])
-                        ->where([$this->Trees->aliasField('object_id') => $relativeTo]),
-                )
-                ->lt(
-                    new IdentifierExpression($this->Trees->ParentNode->aliasField('tree_right')),
-                    $this->Trees->find()
-                        ->select([$this->Trees->aliasField('tree_right')])
-                        ->where([$this->Trees->aliasField('object_id') => $relativeTo]),
-                );
-        }
-        $query = $query
-            ->select([
-                // TODO: use QueryExpressions for this:
-                'path_ids' => 'GROUP_CONCAT(ParentNode.object_id ORDER BY ParentNode.tree_left SEPARATOR \',\')',
-            ])
-            ->innerJoin(
-                [$this->Trees->ParentNode->getName() => $this->Trees->ParentNode->getTable()],
-                $exp,
-            );
-
-        // Join with objects to get path unames.
-        $query = $query
-            ->select([
-                // TODO: use QueryExpressions for this:
-                'path' => 'GROUP_CONCAT(Objects.uname ORDER BY ParentNode.tree_left SEPARATOR \'/\')',
-            ])
-            ->innerJoin(
-                [$this->Trees->ParentNode->Objects->getName() => $this->Trees->ParentNode->Objects->getTable()],
-                $query->newExpr()
-                    ->eq(
-                        new IdentifierExpression($this->Trees->ParentNode->Objects->aliasField('id')),
-                        new IdentifierExpression($this->Trees->ParentNode->aliasField('object_id')),
+                            ->unionAll(
+                                $this->Trees->find()
+                                    ->select([
+                                        'paths.canonical',
+                                        new FunctionExpression('JSON_ARRAY_APPEND', [
+                                            new IdentifierExpression('paths.reverse_path_ids'),
+                                            '$',
+                                            new IdentifierExpression($this->Trees->aliasField('object_id')),
+                                        ]),
+                                        $query->func()->concat([
+                                            new IdentifierExpression($this->Trees->Objects->aliasField('uname')),
+                                            '/',
+                                            new IdentifierExpression('paths.path'),
+                                        ]),
+                                        $this->Trees->aliasField('parent_id'),
+                                    ])
+                                    ->innerJoinWith($this->Trees->Objects->getName())
+                                    ->innerJoin(
+                                        'paths',
+                                        fn(QueryExpression $exp): QueryExpression => $exp
+                                            ->equalFields('paths.parent_id', $this->Trees->aliasField('object_id')),
+                                    ),
+                            ),
                     ),
+            )
+            ->select([
+                'canonical' => 'paths.canonical',
+                'reverse_path_ids' => 'paths.reverse_path_ids',
+                'path' => 'paths.path',
+            ])
+            ->from('paths')
+            ->where(
+                fn(QueryExpression $exp): QueryExpression => $relativeTo
+                    ? $exp->eq('paths.parent_id', $relativeTo)
+                    : $exp->isNull('paths.parent_id'),
             );
-
-        if ($query instanceof SelectQuery) {
-            $query->useReadRole();
-        }
-
-        return $query->disableHydration();
     }
 
     /**

--- a/src/Model/TreeLoader.php
+++ b/src/Model/TreeLoader.php
@@ -174,7 +174,8 @@ class TreeLoader
                 fn(QueryExpression $exp): QueryExpression => $relativeTo
                     ? $exp->eq('paths.parent_id', $relativeTo)
                     : $exp->isNull('paths.parent_id'),
-            );
+            )
+            ->orderDesc('paths.canonical');
     }
 
     /**


### PR DESCRIPTION
This MR updates the CakePHP dependency to v4.5 and makes use of a read connection, if configured in the BEdita project (see [here](https://book.cakephp.org/4/en/orm/database-basics.html#read-and-write-connections) for CakePHP's documentation).